### PR TITLE
Remove timestamps of dummy data

### DIFF
--- a/compose/error.go
+++ b/compose/error.go
@@ -23,6 +23,5 @@ var SingleError = []byte(`
 	},
 
 "id":"e99fd5d7-516f-422d-a6fe-3550a49283e0",
-"timestamp":"2018-01-09T03:35:37.604813Z",
 "transaction":{"id":"87d45146-e0ce-4a04-877c-a672921df059"}}
 `)

--- a/compose/transaction.go
+++ b/compose/transaction.go
@@ -17,7 +17,6 @@ var SingleTransaction = []byte(`
 	"tags":{},
 	"user":{"id":null,"is_authenticated":false,"username":""}
 },
-"timestamp":"2018-01-09T03:35:37.604813Z",
 "type":"request",
 "duration":25.555133819580078,
 "id":"9eb1899c-f767-4f40-85af-e2de18aaaf0c",


### PR DESCRIPTION
Let  it generate it to the apm-server instead.

This way each document will be indexed with a different timestamp.