### PR TITLE
Add throttling option to load tests

### DIFF
--- a/server/api/commands.go
+++ b/server/api/commands.go
@@ -28,13 +28,13 @@ import (
 // it will send `N` simultaneous requests repeatedly as fast as possible for the given `duration`
 // if `spans/transaction is` 0, it creates errors; otherwise it creates transactions
 // blocks current goroutine for as long as `duration` or until waitForCancel returns
-func LoadTest(w stdio.Writer, state State, waitForCancel func(), cmd ...string) (string, TestReport) {
+func LoadTest(w stdio.Writer, state State, waitForCancel func(), throttle string, cmd ...string) (string, TestReport) {
 	duration, err := time.ParseDuration(strcoll.Nth(0, cmd))
 	events, err := atoi(strcoll.Nth(1, cmd), err)
 	spans, err := atoi(strcoll.Nth(2, cmd), err)
 	frames, err := atoi(strcoll.Nth(3, cmd), err)
 	conc, err := atoi(strcoll.Nth(4, cmd), err)
-	qps := math.MaxInt16
+	qps, err := atoi(throttle, err)
 	reqBody := compose.TransactionRequest(events, spans, frames)
 	url := "/v1/transactions"
 	if spans == 0 {
@@ -288,7 +288,7 @@ func Help() string {
 	io.ReplyNL(w, io.Magenta+"        -m, --make"+io.Grey+" runs make")
 	io.ReplyNL(w, io.Magenta+"        -v, --verbose"+io.Grey+" shows the output")
 	io.ReplyNL(w, io.Grey+"    when using docker, the only applicable option is -v, all the others are implicitly used")
-	io.ReplyNL(w, io.Magenta+"test <duration> <events> <spans> <frames> <concurrency> [<apmserver-flags> --mem <mem-limit>]")
+	io.ReplyNL(w, io.Magenta+"test <duration> <events> <spans> <frames> <concurrency> [<apmserver-flags> <OPTIONS>...]")
 	io.ReplyNL(w, io.Grey+"    starts the apm-server and performs a workload test against it")
 	io.ReplyNL(w, io.Magenta+"        <duration>"+io.Grey+" duration of the load test (eg \"1m\")")
 	io.ReplyNL(w, io.Magenta+"        <events>"+io.Grey+" events per request, either transactions or errors")
@@ -296,8 +296,10 @@ func Help() string {
 	io.ReplyNL(w, io.Magenta+"        <frames>"+io.Grey+" frames per document, either spans or errors")
 	io.ReplyNL(w, io.Magenta+"        <concurrency>"+io.Grey+" number of simultaneous queries to send")
 	io.ReplyNL(w, io.Magenta+"        <apmserver-flags>"+io.Grey+" any flags passed to apm-server (elasticsearch url/username/password and apm-server url are overwritten)")
-	io.ReplyNL(w, io.Magenta+"        <mem-limit>"+io.Grey+" memory limit passed to docker run, it doesn't have effect when running apm-server locally")
+	io.ReplyNL(w, io.Grey+"    OPTIONS:")
+	io.ReplyNL(w, io.Magenta+"        --mem <mem-limit>"+io.Grey+" memory limit passed to docker run, it doesn't have effect when running apm-server locally")
 	io.ReplyNL(w, io.Grey+"        defaults to 4g")
+	io.ReplyNL(w, io.Magenta+"        --throttle <throttle>"+io.Grey+" upper limit of queries per second to send")
 	io.ReplyNL(w, io.Magenta+"apm tail [-<n> <pattern>]")
 	io.ReplyNL(w, io.Grey+"    shows the last lines of the apm server log")
 	io.ReplyNL(w, io.Magenta+"        -<n>"+io.Grey+" shows the last <n> lines up to 1000, defaults to 10")

--- a/server/api/commands_test.go
+++ b/server/api/commands_test.go
@@ -20,7 +20,7 @@ func TestInvalidLoadCmds(t *testing.T) {
 		{"1s", "1", "1", "1"},
 	} {
 		bw := io.NewBufferWriter()
-		out, ret := LoadTest(bw, MockState{}, nil, invalidCmd...)
+		out, ret := LoadTest(bw, MockState{}, nil, "32767", invalidCmd...)
 		assert.Contains(t, out, io.Red)
 		assert.Equal(t, ret, TestReport{})
 	}
@@ -29,7 +29,7 @@ func TestInvalidLoadCmds(t *testing.T) {
 func TestLoadNotReady(t *testing.T) {
 	bw := io.NewBufferWriter()
 	cmd := []string{"1s", "1", "0", "1", "1"}
-	out, ret := LoadTest(bw, MockState{Ok: errors.New("not ready")}, nil, cmd...)
+	out, ret := LoadTest(bw, MockState{Ok: errors.New("not ready")}, nil, "32767", cmd...)
 	assert.Equal(t, "not ready", tests.WithoutColors(out))
 	assert.Equal(t, ret, TestReport{})
 }
@@ -41,7 +41,7 @@ func TestLoadCancelled(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	s := MockState{MockApm{url: "localhost:822222"}, MockEs{}, nil}
-	out, ret := LoadTest(bw, s, cancel, cmd...)
+	out, ret := LoadTest(bw, s, cancel, "32767", cmd...)
 	assert.Equal(t, "\nwork cancelled\n", tests.WithoutColors(out))
 	assert.Equal(t, ret, TestReport{})
 }
@@ -56,7 +56,7 @@ func TestLoadOk(t *testing.T) {
 		MockApm{url: "localhost:822222", branch: "master"},
 		MockEs{url: "localhost:922222", docs: 10},
 		nil}
-	out, ret := LoadTest(bw, s, cancel, cmd...)
+	out, ret := LoadTest(bw, s, cancel, "32767", cmd...)
 	assert.Equal(t, `
 on branch master , cmd = [1s 1 2 1 0]
 

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -175,6 +175,10 @@ func (env *evalEnvironment) EvalAndUpdate(usr string, conn Connection) {
 			if !docker.IsDockerized(env.apm) {
 				limit = "-1"
 			}
+
+			var throttle string
+			args1, throttle = io.ParseCmdOption(args1, "--throttle", "32767", true)
+
 			flags := apmFlags(*env.es, env.apm.Url(), strcoll.Rest(5, args1))
 
 			// starts apm-server process
@@ -185,7 +189,7 @@ func (env *evalEnvironment) EvalAndUpdate(usr string, conn Connection) {
 
 			// load test and teardown
 			var report api.TestReport
-			out, report = api.LoadTest(conn, env, conn.waitForCancel, args1...)
+			out, report = api.LoadTest(conn, env, conn.waitForCancel, throttle, args1...)
 
 			var mem int64
 			if env.apm.IsRunning() {


### PR DESCRIPTION
Before it was hardcoded to a high number.

This keeps using that number as default, which pretty much means "disabled".