### PR TITLE
Delete apm-* on user action instead of automatically.

### DIFF
--- a/server/api/commands.go
+++ b/server/api/commands.go
@@ -58,7 +58,7 @@ func LoadTest(w stdio.Writer, state State, waitForCancel func(), cmd ...string) 
 		RequestTimeout:     30,
 		DisableCompression: false,
 	})[0]
-
+	docsBefore := state.ElasticSearch().Count()
 	start := time.Now()
 	go work.Run()
 	io.ReplyNL(w, io.Grey+fmt.Sprintf("started new work, payload size is %s...",
@@ -97,7 +97,7 @@ func LoadTest(w stdio.Writer, state State, waitForCancel func(), cmd ...string) 
 			Branch:       state.ApmServer().Branch(),
 			TotalRes202:  codes[202],
 			TotalRes:     totalResponses,
-			TotalIndexed: state.ElasticSearch().Count(),
+			TotalIndexed: state.ElasticSearch().Count() - docsBefore,
 		}
 
 		io.ReplyNL(bw, fmt.Sprintf("\n%son branch %s , cmd = %v\n", io.Yellow,
@@ -270,6 +270,8 @@ func Help() string {
 	io.ReplyNL(w, io.Grey+"    connects to an elasticsearch node with given parameters")
 	io.ReplyNL(w, io.Magenta+"        last"+io.Grey+" uses the last working parameters")
 	io.ReplyNL(w, io.Magenta+"        local"+io.Grey+" short for http://localhost:9200")
+	io.ReplyNL(w, io.Magenta+"elasticsearch reset")
+	io.ReplyNL(w, io.Grey+"    deletes all the apm-* indices")
 	io.ReplyNL(w, io.Magenta+"apm use [<dir> | last | docker | local]")
 	io.ReplyNL(w, io.Grey+"    informs the directory of the apm-server repo")
 	io.ReplyNL(w, io.Magenta+"        last"+io.Grey+" uses the last working directory")

--- a/server/api/commands_test.go
+++ b/server/api/commands_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"regexp"
-
 	"github.com/elastic/hey-apm/server/api/io"
 	"github.com/elastic/hey-apm/server/tests"
 	"github.com/stretchr/testify/assert"
@@ -59,8 +57,6 @@ func TestLoadOk(t *testing.T) {
 		MockEs{url: "localhost:922222", docs: 10},
 		nil}
 	out, ret := LoadTest(bw, s, cancel, cmd...)
-	re := regexp.MustCompile("docs indexed (.*)sec")
-	out = re.ReplaceAllString(out, "docs indexed (10 / sec")
 	assert.Equal(t, `
 on branch master , cmd = [1s 1 2 1 0]
 
@@ -68,7 +64,7 @@ pushed 0 b / sec , accepted 0 b / sec
 localhost:822222/v1/transactions 0
   total	0 responses (0.00 rps)
 
-10 docs indexed (10 / sec) 
+0 docs indexed (0.00 / sec) 
 `,
 		tests.WithoutColors(out))
 
@@ -88,7 +84,7 @@ localhost:822222/v1/transactions 0
 	assert.Equal(t, 0, ret.TotalRes202)
 	assert.Equal(t, float64(0), ret.rps202())
 	assert.Equal(t, int64(0), ret.MaxRss)
-	assert.Equal(t, int64(10), ret.TotalIndexed)
+	assert.Equal(t, int64(0), ret.TotalIndexed)
 	assert.Len(t, ret.ReportId, 8)
 	assert.InDelta(t, time.Now().Unix(), ret.date().Unix(), time.Second.Seconds())
 }

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -140,6 +140,9 @@ func (env *evalEnvironment) EvalAndUpdate(usr string, conn Connection) {
 		case fn == "elasticsearch" && arg1 == "use":
 			out, env.es = elasticSearchUse(usr, args2...)
 			err = env.es.useErr
+		case fn == "elasticsearch" && arg1 == "reset":
+			err = reset(env.es)
+			out = fmt.Sprintf("%s %d indexed docs", io.Grey, env.es.Count())
 		case fn == "apm" && arg1 == "use":
 			out, env.apm = apmUse(usr, strcoll.Nth(2, cmd))
 			err = env.apm.useErr
@@ -174,11 +177,8 @@ func (env *evalEnvironment) EvalAndUpdate(usr string, conn Connection) {
 			}
 			flags := apmFlags(*env.es, env.apm.Url(), strcoll.Rest(5, args1))
 
-			// deletes apm-* indices and starts apm-server process
-			err = reset(env.es)
-			if err == nil {
-				err, env.apm = apmStart(conn, *env.apm, conn.CancelSig.Broadcast, flags, limit)
-			}
+			// starts apm-server process
+			err, env.apm = apmStart(conn, *env.apm, conn.CancelSig.Broadcast, flags, limit)
 			if err != nil {
 				break
 			}


### PR DESCRIPTION
This is so to keep around data generated in different runs and better explore it in kibana