### PR TITLE
run dep during image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.idea/
+vendor/
+hey-apm

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Basic load generation for apm-server built on [hey](https://github.com/rakyll/he
 # Install
 
 ```
-# create vendor/
+# populate vendor/
 go get github.com/golang/dep/cmd/dep
 dep ensure -v
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,11 @@
 # from .. - docker build -f docker/Dockerfile .
-FROM golang:1.9
+FROM golang:1.11
 RUN useradd hey
 
 WORKDIR /go/src/github.com/elastic/hey-apm
+RUN go get -u github.com/golang/dep/cmd/dep
 COPY . .
+RUN dep ensure
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o hey-apm .
 
 FROM scratch


### PR DESCRIPTION
so those without vendor/ populate can still build docker images