### PR TITLE
support for testing multiple apm-servers 

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func desc(t *target.Target) {
 		zw.Write(t.Body)
 		zw.Close()
 	}
-	fmt.Printf("%s %s - %d (%d gz) bytes", t.Method, t.Url, len(t.Body), len(gzBody.Bytes()))
+	fmt.Printf("%s %s - %d (%d gz) bytes", t.Method, t.Config.Endpoint, len(t.Body), len(gzBody.Bytes()))
 
 	var j map[string]interface{}
 	if err := json.Unmarshal(t.Body, &j); err != nil {
@@ -125,7 +125,7 @@ func dumpLoadbeat(t *target.Target) {
 	fmt.Fprintf(f, "    - number of agents: %d\n", *numAgents)
 	fmt.Fprintf(f, "      qps: %.5f\n", *qps)
 	fmt.Fprintf(f, "      method: %s\n", t.Method)
-	fmt.Fprintf(f, "      url: %s\n", t.Url)
+	fmt.Fprintf(f, "      url: %s\n", t.Config.Endpoint)
 	if len(t.Body) > 0 {
 		fmt.Fprintln(f, "      headers:")
 		fmt.Fprintln(f, "        - Content-Type:application/json")
@@ -195,15 +195,15 @@ func main() {
 	start := time.Now()
 	done := make(chan struct{})
 	go func(w *requester.Work) {
-		logger.Println("[info] starting worker for", t.Url)
+		logger.Println("[info] starting worker for", t.Config.Endpoint)
 		w.Run()
-		logger.Println("[info] worker done for", t.Url)
+		logger.Println("[info] worker done for", t.Config.Endpoint)
 		close(done)
 	}(work)
 
 	stopWorking := func() {
 		go func(w *requester.Work) {
-			logger.Println("[info] stopping worker for", t.Url)
+			logger.Println("[info] stopping worker for", t.Config.Endpoint)
 			w.Stop()
 		}(work)
 	}

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -16,6 +16,7 @@ package requester
 
 import (
 	"bytes"
+	"container/ring"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,12 @@ import (
 	"testing"
 	"time"
 )
+
+func testRing(s string) *ring.Ring {
+	r := ring.New(1)
+	r.Value = s
+	return r
+}
 
 func TestN(t *testing.T) {
 	var count int64
@@ -35,7 +42,7 @@ func TestN(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL, nil)
 	w := &Work{
-		Req: &SimpleReq{Request: req},
+		Req: &SimpleReq{Request: req, URLs: testRing(server.URL)},
 		N:   20,
 		C:   2,
 	}
@@ -56,7 +63,7 @@ func TestQps(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL, nil)
 	w := &Work{
-		Req: &SimpleReq{Request: req, QPS: 1},
+		Req: &SimpleReq{Request: req, QPS: 1, URLs: testRing(server.URL)},
 		N:   20,
 		C:   2,
 	}
@@ -90,7 +97,7 @@ func TestRequest(t *testing.T) {
 	req.Header = header
 	req.SetBasicAuth("username", "password")
 	w := &Work{
-		Req: &SimpleReq{Request: req},
+		Req: &SimpleReq{Request: req, URLs: testRing(server.URL)},
 		N:   1,
 		C:   1,
 	}
@@ -122,7 +129,7 @@ func TestBody(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", server.URL, bytes.NewBuffer([]byte("Body")))
 	w := &Work{
-		Req: &SimpleReq{Request: req, RequestBody: []byte("Body")},
+		Req: &SimpleReq{Request: req, RequestBody: []byte("Body"), URLs: testRing(server.URL)},
 		N:   10,
 		C:   1,
 	}

--- a/server/api/commands_test.go
+++ b/server/api/commands_test.go
@@ -24,7 +24,7 @@ func basicTarget(t *testing.T, opts ...target.OptionFunc) *target.Target {
 		target.NumAgents("0"),
 		target.Throttle("1"),
 	}
-	target, err := target.NewTargetFromOptions("", append(required, opts...)...)
+	target, err := target.NewTargetFromOptions([]string{""}, append(required, opts...)...)
 	assert.NoError(t, err)
 	return target
 }
@@ -56,7 +56,7 @@ func TestLoadOk(t *testing.T) {
 		MockEs{url: "localhost:922222", docs: 10},
 		nil}
 	ret := LoadTest(bw, s, cancel, *basicTarget(t))
-	assert.Contains(t, bw.String(), "started new work, url /intake/v2/events")
+	assert.Contains(t, bw.String(), "started new work")
 
 	assert.Equal(t, time.Second, ret.Duration)
 	assert.Equal(t, 0, ret.Errors)
@@ -64,7 +64,7 @@ func TestLoadOk(t *testing.T) {
 	assert.Equal(t, 1, ret.Spans)
 	assert.Equal(t, 1, ret.Frames)
 	assert.Equal(t, "localhost:922222", ret.ElasticUrl)
-	assert.Equal(t, "localhost:822222", ret.ApmUrl)
+	assert.Equal(t, "localhost:822222", ret.ApmUrls)
 	assert.Equal(t, 0, ret.Agents)
 	assert.Equal(t, 1, ret.Throttle)
 	assert.Equal(t, "master", ret.Branch)
@@ -152,7 +152,7 @@ func TestDump(t *testing.T) {
 	out := Dump(mfw, "json", "1", "1", "1", "1")
 	assert.Contains(t, out, "written to disk", tests.WithoutColors(out))
 	for _, jsonKey := range []string{"\"metadata\"", "\"user\"", "\"process\"", "\"system\"",
-	"\"service\"", "\"transaction\"", "\"error\"", "\"span\"", "\"abs_path\""} {
+		"\"service\"", "\"transaction\"", "\"error\"", "\"span\"", "\"abs_path\""} {
 		assert.Contains(t, mfw.Data, jsonKey)
 	}
 

--- a/server/api/mock_state_impl.go
+++ b/server/api/mock_state_impl.go
@@ -6,8 +6,8 @@ type MockApm struct {
 	L                []string
 }
 
-func (a MockApm) Url() string {
-	return a.url
+func (a MockApm) Urls() []string {
+	return []string{a.url}
 }
 
 func (a MockApm) Dir() string {

--- a/server/api/reports_test.go
+++ b/server/api/reports_test.go
@@ -40,8 +40,8 @@ var report = TestReport{
 		GzipBodySize:   1,
 		BodySize:       1,
 		ElasticUrl:     "http://localhost:9200",
-		ApmUrl:         "http://localhost:8200",
-		ApmHost:        "localhost",
+		ApmUrls:        "http://localhost:8200",
+		ApmHosts:       "localhost",
 		Branch:         "master",
 		TotalResponses: 1,
 		// AcceptedResponses: 1,
@@ -139,7 +139,7 @@ func (b *builder) setSize(x int64) *builder {
 //}
 
 func (b *builder) setApm(s string) *builder {
-	b.ApmUrl = s
+	b.ApmUrls = s
 	return b
 }
 

--- a/server/api/state.go
+++ b/server/api/state.go
@@ -1,7 +1,7 @@
 package api
 
 type ApmServer interface {
-	Url() string
+	Urls() []string
 	Dir() string
 	Branch() string
 	PrettyRevision() string

--- a/server/client/state_impl.go
+++ b/server/client/state_impl.go
@@ -86,15 +86,11 @@ func (apm apm) PrettyRevision() string {
 	return apm.prettyRev
 }
 
-func (apm apm) Url() string {
-	if apm.isDockerized {
-		return "http://0.0.0.0:8200"
-	} else if apm.isRemote {
-		return apm.loc
-	} else {
-		return "http://localhost:8200"
-
+func (apm apm) Urls() []string {
+	if len(apm.urls) == 0 {
+		return []string{apmUrl(apm)}
 	}
+	return apm.urls
 }
 
 func (apm apm) Dir() string {

--- a/server/client/stress_test.go
+++ b/server/client/stress_test.go
@@ -32,14 +32,14 @@ func setupEnv(flags []string) (*evalEnvironment, []string, error) {
 		_, environment.apm = apmSwitch(console, apmDir, "master", "", []string{"c", "m", "u", "v"})
 	})
 
-	flags = apmFlags(*environment.es, environment.apm.Url(), append(flags, "-E", "apm-server.shutdown_timeout=1s"))
+	flags = apmFlags(*environment.es, environment.apm.Urls()[0], append(flags, "-E", "apm-server.shutdown_timeout=1s"))
 	err := apmStop(environment.apm)
 	if err == nil {
 		time.Sleep(time.Second * 5)
 		err, environment.apm = apmStart(console, *environment.apm, func() {}, flags, "-1")
 	}
 	if err == nil {
-		err = waitForServer(environment.apm.Url())
+		err = waitForServer(environment.apm.Urls()[0])
 	}
 	return environment, flags, err
 }
@@ -126,7 +126,7 @@ func doBenchmark(memLimit int64, flags []string, workload ...string) ([]api.Test
 		return nil, err
 	}
 	block := func() { select {} }
-	target, err := target.NewTargetFromOptions("",
+	target, err := target.NewTargetFromOptions([]string{},
 		target.NumErrors(workload[0]),
 		target.NumTransactions(workload[1]),
 		target.NumSpans(workload[2]),
@@ -144,7 +144,6 @@ func doBenchmark(memLimit int64, flags []string, workload ...string) ([]api.Test
 		env.apm.revision,
 		env.apm.revDate,
 		env.apm.unstaged,
-		env.apm.isRemote,
 		maxRssUsed(env.apm.cmd),
 		memLimit,
 		removeSensitiveFlags(flags),

--- a/target/target_test.go
+++ b/target/target_test.go
@@ -11,20 +11,21 @@ func TestTargets(t *testing.T) {
 	var target *Target
 	var err error
 
-	_, err = NewTargetFromOptions("", RunTimeout("2"))
+	urls := []string{""}
+	_, err = NewTargetFromOptions(urls, RunTimeout("2"))
 	assert.Error(t, err)
 	assert.Equal(t, "time: missing unit in duration 2", err.Error())
 
-	target, err = NewTargetFromOptions("", RunTimeout("2s"))
+	target, err = NewTargetFromOptions(urls, RunTimeout("2s"))
 	assert.NoError(t, err)
 	assert.Equal(t, time.Second*2, target.Config.RunTimeout)
 
-	target, err = NewTargetFromOptions("", NumTransactions("a"), RunTimeout("3s"))
+	target, err = NewTargetFromOptions(urls, NumTransactions("a"), RunTimeout("3s"))
 	assert.Error(t, err)
 	assert.Equal(t, "strconv.Atoi: parsing \"a\": invalid syntax", err.Error())
 	assert.Equal(t, time.Duration(0), target.Config.RunTimeout)
 
-	target, err = NewTargetFromOptions("", RequestTimeout("1s"))
+	target, err = NewTargetFromOptions(urls, RequestTimeout("1s"))
 	assert.NoError(t, err)
 	assert.Equal(t, time.Duration(1)*time.Second, target.Config.RequestTimeout)
 }


### PR DESCRIPTION
This enables eg:
`apm use http:apm-server-1:8200 http:apm-server-2:8200 http:apm-server-3:8200`

Request are round-robin to all apm-servers configured.

Analysis supports filtering and breakdown by number of apm-server instances (`apms`) and by `apm_host`. `apm_host` is the concatenated lists of hosts, separated by comma, ordered alphabetically. eg  `apm-server-1,apm-server-2`

This PR includes a bug fix: when there are duplicated results, only the best one is showed. 
The criteria for defining the "best" considered Max RSS usage, but with unmanaged apm-servers that attribute is not known. In this PR we fallback to throughput.