### PR TITLE
leftovers and minor fixes

### DIFF
--- a/server/api/commands.go
+++ b/server/api/commands.go
@@ -326,7 +326,6 @@ func Help() string {
 	io.ReplyNL(w, io.Magenta+"                revision"+io.Grey+" git commit")
 	io.ReplyNL(w, io.Magenta+"                apm_host"+io.Grey+" apm hostname(s) separated by ',' ordered alphabetically")
 	io.ReplyNL(w, io.Magenta+"                apms"+io.Grey+" number of apm servers running")
-	io.ReplyNL(w, io.Magenta+"                limit"+io.Grey+" memory limit passed to docker")
 	io.ReplyNL(w, io.Magenta+"                <flag>"+io.Grey+" flag passed to the apm-server with -E")
 	io.ReplyNL(w, io.Magenta+"        <FILTER>"+io.Grey+" returns only reports matching all given filters, specified like <FIELD>=|!=|<|><value>")
 	io.ReplyNL(w, io.Grey+"        dates must be formatted like \"2018-28-02\" and durations like \"1m\"")

--- a/server/api/commands_test.go
+++ b/server/api/commands_test.go
@@ -174,7 +174,7 @@ func TestDump(t *testing.T) {
 
 func TestStatus(t *testing.T) {
 	state := MockState{
-		MockApm{dir: "NOTADIR", url: "localhost:8200"},
+		MockApm{dir: "dir", url: "localhost:8200"},
 		MockEs{url: "localhost:9200", health: "great", docs: 17},
 		nil,
 	}
@@ -182,7 +182,9 @@ func TestStatus(t *testing.T) {
 	assert.Equal(t,
 		`ElasticSearch [localhost:9200]: great ,  17 docs
 ApmServer [localhost:8200]: not running
-Can't ch to directory NOTADIR (hint: apm use <dir>)
+
+Using dir
+Git Info: unknown branch (hint: apm switch <branch>)
 `,
 		tests.WithoutColors(out))
 }

--- a/server/api/reports.go
+++ b/server/api/reports.go
@@ -315,7 +315,8 @@ func apmFlags(r TestReport) map[string]string {
 	for _, flag := range r.apmFlags() {
 		if prev == "-E" &&
 			!s.HasPrefix(flag, "apm-server.host") &&
-			!s.HasPrefix(flag, "output.elasticsearch") {
+			!s.HasPrefix(flag, "output.elasticsearch.username") &&
+			!s.HasPrefix(flag, "output.elasticsearch.password") {
 			split := s.Split(flag, "=")
 			if len(split) == 2 {
 				ret[s.TrimSpace(split[0])] = s.TrimSpace(split[1])

--- a/server/api/reports_test.go
+++ b/server/api/reports_test.go
@@ -23,7 +23,6 @@ var report = TestReport{
 	User:             "test_user",
 	Timestamp:        time.Now(),
 	Lang:             "python",
-	Limit:            -1,
 	Revision:         "rev12345678",
 	RevDate:          "Fri, 20 Apr 2018 10:00:00 +0200",
 	ApmFlags:         "-E apm-server.host=http://localhost:8200 -E output.elasticsearch.hosts=[http://localhost:9200]",
@@ -164,7 +163,7 @@ func (b *builder) addFlag(s string) *builder {
 }
 
 func (b *builder) get() TestReport {
-	r := NewReport(b.TestResult, b.User, "", b.Revision, b.RevDate, false, b.MaxRss, b.Limit, b.apmFlags(), io.NewBufferWriter())
+	r := NewReport(b.TestResult, b.User, "", b.Revision, b.RevDate, false, b.MaxRss, b.apmFlags(), io.NewBufferWriter())
 	r.ReportId = b.ReportId
 	r.ReportDate = b.ReportDate
 	return r

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -289,24 +289,24 @@ func apmSwitch(w stdio.Writer, apmLoc string, apmUrls []string, branch, revision
 	fetchCmd := "true"
 	if strcoll.ContainsAny(opts, "f", "fetch") || apm.isDockerized() {
 		if len(tokens) == 2 {
-			fetchCmd = fmt.Sprintf("'git fetch %s'", tokens[0])
+			fetchCmd = fmt.Sprintf("git fetch %s", tokens[0])
 		} else {
-			fetchCmd = "'git fetch origin'"
+			fetchCmd = "git fetch origin"
 		}
 	}
 
 	checkoutCmd := "true"
 	if strcoll.ContainsAny(opts, "c", "checkout") || apm.isDockerized() {
 		if revision != "" {
-			checkoutCmd = fmt.Sprintf("'git checkout %s'", revision)
+			checkoutCmd = fmt.Sprintf("git checkout %s", revision)
 		} else {
-			checkoutCmd = fmt.Sprintf("'git checkout %s'", branch)
+			checkoutCmd = fmt.Sprintf("git checkout %s", branch)
 		}
 	}
 
 	makeUpdateCmd := "true"
 	if strcoll.ContainsAny(opts, "u", "make-update") || apm.isDockerized() {
-		makeUpdateCmd = "'make update'"
+		makeUpdateCmd = "make update"
 	}
 
 	makeCmd := "true"


### PR DESCRIPTION
Turns out that wrapping commands in single quotes doesn't fix the issue we found, but breaks it locally at least in Linux.

I was also preventing eg `output.elasticsearch.worker` from being saved in the report, this fixes that