### PR TITLE
implement a custom transport for the tracer 

### DIFF
--- a/agent/tracer.go
+++ b/agent/tracer.go
@@ -1,18 +1,48 @@
 package agent
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"net/url"
+	"sync"
 	"time"
+
+	"github.com/elastic/hey-apm/conv"
+	"github.com/elastic/hey-apm/strcoll"
 
 	"go.elastic.co/apm"
 	apmtransport "go.elastic.co/apm/transport"
 )
 
-func Tracer(logger apm.Logger, serverUrl, serverSecret string, maxSpans int) *apm.Tracer {
-	tracer := apm.DefaultTracer
-	tracer.SetLogger(logger)
-	tracer.SetMetricsInterval(0) // disable metrics
-	transport := tracer.Transport.(*apmtransport.HTTPTransport)
+type Tracer struct {
+	*apm.Tracer
+	TransportStats *TransportStats
+}
+
+type TransportStats struct {
+	Accepted    uint64
+	TopErrors   []string
+	NumRequests uint64
+}
+
+func (t Tracer) Close() {
+	t.Tracer.Close()
+	rt := t.Transport.(*apmtransport.HTTPTransport).Client.Transport.(*roundTripper)
+	rt.wg.Wait()
+	close(rt.c)
+}
+
+func NewTracer(logger apm.Logger, serverUrl, serverSecret string, maxSpans int) *Tracer {
+
+	goTracer := apm.DefaultTracer
+	goTracer.SetLogger(logger)
+	goTracer.SetMetricsInterval(0) // disable metrics
+	goTracer.SetSpanFramesMinDuration(1 * time.Nanosecond)
+	goTracer.SetMaxSpans(maxSpans)
+
+	transport := goTracer.Transport.(*apmtransport.HTTPTransport)
 	transport.SetUserAgent("hey-apm")
 	if serverSecret != "" {
 		transport.SetSecretToken(serverSecret)
@@ -20,12 +50,70 @@ func Tracer(logger apm.Logger, serverUrl, serverSecret string, maxSpans int) *ap
 	if serverUrl != "" {
 		u, err := url.Parse(serverUrl)
 		if err != nil {
-			logger.Errorf("invalid apm server url:", err)
+			panic(err)
 		}
 		transport.SetServerURL(u)
 	}
+	rt := &roundTripper{c: make(chan []byte, 0)}
+	transport.Client.Transport = rt
 
-	tracer.SetSpanFramesMinDuration(1 * time.Nanosecond)
-	tracer.SetMaxSpans(maxSpans)
+	tracer := &Tracer{goTracer, &TransportStats{}}
+
+	go func() {
+		for {
+			select {
+			case response := <-rt.c:
+				var m map[string]interface{}
+				if err := json.Unmarshal(response, &m); err != nil {
+					return
+				}
+				tracer.TransportStats.Accepted += conv.AsUint64(m, "accepted")
+				tracer.TransportStats.NumRequests += 1
+				for _, i := range conv.AsSlice(m, "errors") {
+					e := conv.AsString(i, "message")
+					if !strcoll.Contains(e, tracer.TransportStats.TopErrors) {
+						tracer.TransportStats.TopErrors = append(tracer.TransportStats.TopErrors, e)
+					}
+				}
+				rt.wg.Done()
+			}
+		}
+	}()
 	return tracer
+}
+
+type roundTripper struct {
+	c  chan []byte
+	wg sync.WaitGroup
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch req.URL.Path {
+	case "/intake/v2/events", "/intake/v2/rum/events":
+	default:
+		return http.DefaultTransport.RoundTrip(req)
+	}
+
+	q := req.URL.Query()
+	q.Set("verbose", "")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	defer resp.Body.Close()
+
+	if resp.Body == http.NoBody {
+		return resp, err
+	}
+
+	b, rerr := ioutil.ReadAll(resp.Body)
+	if rerr == nil {
+		rt.c <- b
+		rt.wg.Add(1)
+		resp.Body = ioutil.NopCloser(bytes.NewReader(b))
+	}
+
+	return resp, err
 }

--- a/conv/conversions.go
+++ b/conv/conversions.go
@@ -3,7 +3,11 @@ package conv
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
+	"strings"
+
+	"github.com/elastic/hey-apm/types"
 )
 
 // shamelessly stolen from http://programming.guide/go/formatting-byte-size-to-human-readable-format.html
@@ -38,7 +42,36 @@ func StringOf(v interface{}) string {
 		return fmt.Sprintf("%d", v)
 	case float64:
 		return fmt.Sprintf("%.2f", v)
+	case []string:
+		return strings.Join(v.([]string), ",")
 	default:
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+func AsFloat64(m interface{}, k string) float64 {
+	return asType(m, k, float64(0)).(float64)
+}
+
+func AsUint64(m interface{}, k string) uint64 {
+	return uint64(AsFloat64(m, k))
+}
+
+func AsSlice(m interface{}, k string) types.Is {
+	return asType(m, k, make(types.Is, 0)).(types.Is)
+}
+
+func AsString(m interface{}, k string) string {
+	return asType(m, k, "").(string)
+}
+
+func asType(m interface{}, k string, v interface{}) interface{} {
+	if m2, ok := m.(types.M); ok {
+		if v2, ok := m2[k]; ok {
+			if reflect.TypeOf(v2) == reflect.TypeOf(v) {
+				return v2
+			}
+		}
+	}
+	return v
 }

--- a/conv/conversions.go
+++ b/conv/conversions.go
@@ -3,6 +3,7 @@ package conv
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -11,17 +12,22 @@ import (
 )
 
 // shamelessly stolen from http://programming.guide/go/formatting-byte-size-to-human-readable-format.html
-func ByteCountDecimal(b int64) string {
+func ByteCountDecimal(z int64) string {
+	n := int64(math.Abs(float64(z)))
 	const unit = 1000
-	if b < unit {
-		return fmt.Sprintf("%d b", b)
+	if n < unit {
+		return fmt.Sprintf("%d n", n)
 	}
 	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
+	for n := n / unit; n >= unit; n /= unit {
 		div *= unit
 		exp++
 	}
-	return fmt.Sprintf("%.1f%cb", float64(b)/float64(div), "kMGTPE"[exp])
+	var neg string
+	if z != n {
+		neg = "-"
+	}
+	return fmt.Sprintf("%s%.1f%cb", neg, float64(n)/float64(div), "kMGTPE"[exp])
 }
 
 // like Atoi for positive integers and error handling
@@ -38,7 +44,7 @@ func Aton(attr string, err error) (int, error) {
 
 func StringOf(v interface{}) string {
 	switch v.(type) {
-	case uint64:
+	case uint64, int64:
 		return fmt.Sprintf("%d", v)
 	case float64:
 		return fmt.Sprintf("%.2f", v)

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/elastic/hey-apm/agent"
@@ -50,7 +49,7 @@ func main() {
 	rand.Seed(*seed)
 	logger.Debugf("random seed: %d", *seed)
 
-	tracer := agent.Tracer(logger, *apmServerUrl, *apmServerSecret, *spanMaxLimit)
+	tracer := agent.NewTracer(logger, *apmServerUrl, *apmServerSecret, *spanMaxLimit)
 
 	w := worker.Worker{
 		ApmLogger:    logger,
@@ -70,11 +69,7 @@ func main() {
 	logger.Debugf("%s elapsed since event generation completed", report.Flushed.Sub(report.End))
 
 	fmt.Println()
-	for _, metric := range report.Stats {
-		name, value := metric.Name, metric.Value
-		name += " " + strings.Repeat(".", 30-len(name))
-		fmt.Printf("%s %s\n", name, value)
-	}
+	report.Print()
 
 	info, err := server.QueryInfo(*apmServerSecret, *apmServerUrl)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -62,6 +62,9 @@ func main() {
 
 	logger.Debugf("start")
 	defer logger.Debugf("finish")
+
+	metricsBefore, merr1 := server.QueryExpvar(*apmServerSecret, *apmServerUrl)
+
 	report, err := w.Work()
 	if err != nil {
 		logger.Errorf(err.Error())
@@ -69,7 +72,17 @@ func main() {
 	logger.Debugf("%s elapsed since event generation completed", report.Flushed.Sub(report.End))
 
 	fmt.Println()
-	report.Print()
+	fmt.Println(report)
+
+	metricsAfter, merr2 := server.QueryExpvar(*apmServerSecret, *apmServerUrl)
+	if merr2 == nil {
+		if merr1 == nil {
+			fmt.Println()
+			fmt.Println(metricsAfter.Memstats.Sub(metricsBefore.Memstats))
+		}
+	} else {
+		logger.Errorf("could not get expvar metrics: %s", merr2.Error())
+	}
 
 	info, err := server.QueryInfo(*apmServerSecret, *apmServerUrl)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 	}
 	w.AddErrors(*errorFrequency, *errorLimit, *errorFrameMinLimit, *errorFrameMaxLimit)
 	w.AddTransactions(*transactionFrequency, *transactionLimit, *spanMinLimit, *spanMaxLimit)
+	w.AddSignalHandling()
 
 	logger.Debugf("start")
 	defer logger.Debugf("finish")

--- a/server/server.go
+++ b/server/server.go
@@ -6,13 +6,52 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
+
+	"github.com/elastic/hey-apm/conv"
+	"github.com/elastic/hey-apm/strcoll"
 )
 
 type Info struct {
 	BuildDate time.Time `json:"build_date"`
 	BuildSha  string    `json:"build_sha"`
 	Version   string    `json:"version"`
+}
+
+type ExpvarMetrics struct {
+	Cmdline  []string `json:"cmdline"`
+	Memstats Memstats `json:"memstats"`
+}
+
+type Memstats struct {
+	TotalAlloc     int64 `json:"TotalAlloc"`
+	HeapAlloc      int64 `json:"HeapAlloc"`
+	Mallocs        int64 `json:"Mallocs"`
+	NumGC          int64 `json:"NumGC"`
+	TotalAllocDiff int64
+	HeapAllocDiff  int64
+}
+
+func (ms Memstats) Sub(ms2 Memstats) Memstats {
+	return Memstats{
+		TotalAlloc:     ms.TotalAlloc,
+		HeapAlloc:      ms.HeapAlloc,
+		TotalAllocDiff: ms.TotalAlloc - ms2.TotalAlloc,
+		HeapAllocDiff:  ms.HeapAlloc - ms2.HeapAlloc,
+		Mallocs:        ms.Mallocs - ms2.Mallocs,
+		NumGC:          ms.NumGC - ms2.NumGC,
+	}
+}
+
+func (ms Memstats) String() string {
+	metrics := strcoll.NewTuples()
+	metrics.Add("heap", conv.ByteCountDecimal(ms.HeapAlloc))
+	metrics.Add("total allocated", conv.ByteCountDecimal(ms.TotalAllocDiff))
+	metrics.Add("heap allocated", conv.ByteCountDecimal(ms.HeapAllocDiff))
+	metrics.Add("mallocs", ms.Mallocs)
+	metrics.Add("num GC", ms.NumGC)
+	return metrics.Format(20)
 }
 
 func (info Info) String() string {
@@ -24,6 +63,26 @@ func (info Info) String() string {
 }
 
 func QueryInfo(secret, url string) (Info, error) {
+	body, err := request(secret, url)
+	info := Info{}
+	if err == nil {
+		err = json.Unmarshal(body, &info)
+	}
+	return info, err
+}
+
+func QueryExpvar(secret, raw string) (ExpvarMetrics, error) {
+	u, _ := url.Parse(raw)
+	u.Path = "/debug/vars"
+	body, err := request(secret, u.String())
+	metrics := ExpvarMetrics{}
+	if err == nil {
+		err = json.Unmarshal(body, &metrics)
+	}
+	return metrics, err
+}
+
+func request(secret, url string) ([]byte, error) {
 	req, _ := http.NewRequest("GET", url, nil)
 	if secret != "" {
 		req.Header.Set("Authorization", "Beater "+secret)
@@ -32,18 +91,15 @@ func QueryInfo(secret, url string) (Info, error) {
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	info := Info{}
 
 	if err != nil {
-		return info, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return info, errs.New("server status not OK: " + resp.Status)
-	}
-
 	body, _ := ioutil.ReadAll(resp.Body)
-	err = json.Unmarshal(body, &info)
-	return info, err
+	if resp.StatusCode >= 300 {
+		return body, errs.New("server status not OK: " + resp.Status)
+	}
+	return body, err
 }

--- a/strcoll/tuple.go
+++ b/strcoll/tuple.go
@@ -1,0 +1,33 @@
+package strcoll
+
+import (
+	"strings"
+
+	"github.com/elastic/hey-apm/conv"
+)
+
+type Tuple struct {
+	First, Second string
+}
+
+type Tuples struct {
+	data []Tuple
+}
+
+func NewTuples() Tuples {
+	return Tuples{data: make([]Tuple, 0)}
+}
+
+func (ts *Tuples) Add(first string, second interface{}) {
+	ts.data = append(ts.data, Tuple{first, conv.StringOf(second)})
+}
+
+func (ts Tuples) Format(padding int) string {
+	lines := make([]string, 0)
+	for _, t := range ts.data {
+		first, second := t.First, t.Second
+		first += " " + strings.Repeat(".", padding-len(first)) + " "
+		lines = append(lines, first+second)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,5 @@
+package types
+
+type M = map[string]interface{}
+
+type Is = []interface{}

--- a/worker/report.go
+++ b/worker/report.go
@@ -1,13 +1,12 @@
 package worker
 
 import (
-	"fmt"
 	"time"
-
-	"github.com/elastic/hey-apm/strcoll"
 
 	"github.com/elastic/hey-apm/agent"
 	"github.com/elastic/hey-apm/numbers"
+	"github.com/elastic/hey-apm/strcoll"
+
 	"go.elastic.co/apm"
 )
 
@@ -55,7 +54,7 @@ func (r Report) SpansPerTransaction() float64 {
 	return numbers.Div(r.SpansSent, r.TransactionsSent)
 }
 
-func (r Report) Print() {
+func (r Report) String() string {
 	metrics := strcoll.NewTuples()
 
 	metrics.Add("transactions sent", r.TransactionsSent)
@@ -90,5 +89,5 @@ func (r Report) Print() {
 		metrics.Add("server errors", r.TopErrors)
 	}
 
-	fmt.Println(metrics.Format(30))
+	return metrics.Format(30)
 }

--- a/worker/report.go
+++ b/worker/report.go
@@ -1,0 +1,94 @@
+package worker
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/hey-apm/strcoll"
+
+	"github.com/elastic/hey-apm/agent"
+	"github.com/elastic/hey-apm/numbers"
+	"go.elastic.co/apm"
+)
+
+type Report struct {
+	apm.TracerStats
+	agent.TransportStats
+	Start   time.Time
+	End     time.Time
+	Flushed time.Time
+}
+
+func (r Report) TransactionSuccess() float64 {
+	return numbers.Perct(r.TransactionsSent, r.TransactionsDropped)
+}
+
+func (r Report) SpanSuccess() float64 {
+	return numbers.Perct(r.SpansSent, r.SpansDropped)
+}
+
+func (r Report) ErrorSuccess() float64 {
+	return numbers.Perct(r.ErrorsSent, r.ErrorsDropped)
+}
+
+func (r Report) EventsSent() uint64 {
+	return r.ErrorsSent + r.SpansSent + r.TransactionsSent
+}
+
+func (r Report) ElapsedSeconds() float64 {
+	return r.Flushed.Sub(r.Start).Seconds()
+}
+
+func (r Report) EventsSentPerSecond() float64 {
+	return float64(r.EventsSent()) / r.ElapsedSeconds()
+}
+
+func (r Report) EventsAcceptedPerSecond() float64 {
+	return float64(r.Accepted) / r.ElapsedSeconds()
+}
+
+func (r Report) EventSuccess() float64 {
+	return numbers.Perct(r.Accepted, r.EventsSent())
+}
+
+func (r Report) SpansPerTransaction() float64 {
+	return numbers.Div(r.SpansSent, r.TransactionsSent)
+}
+
+func (r Report) Print() {
+	metrics := strcoll.NewTuples()
+
+	metrics.Add("transactions sent", r.TransactionsSent)
+	metrics.Add("transactions dropped", r.TransactionsDropped)
+	if r.TransactionsSent+r.TransactionsDropped > 0 {
+		metrics.Add(" - success %", r.TransactionSuccess())
+		metrics.Add("spans sent", r.SpansSent)
+		metrics.Add("spans dropped", r.SpansDropped)
+		metrics.Add(" - success %", r.SpanSuccess())
+		if r.TransactionsSent > 0 {
+			metrics.Add("spans sent per transaction", r.SpansPerTransaction())
+		}
+	}
+	metrics.Add("errors sent", r.ErrorsSent)
+	metrics.Add("errors dropped", r.ErrorsDropped)
+	if r.ErrorsSent+r.ErrorsDropped > 0 {
+		metrics.Add(" - success %", r.ErrorSuccess())
+	}
+	if r.ElapsedSeconds() > 0 {
+		metrics.Add("total events sent", r.EventsSent())
+		metrics.Add(" - per second", r.EventsSentPerSecond())
+		metrics.Add(" - accepted", int64(r.Accepted))
+		if r.Accepted > 0 && r.EventsSent() != r.Accepted {
+			metrics.Add("   - per second", r.EventsAcceptedPerSecond())
+			metrics.Add("   - success %", r.ErrorSuccess())
+		}
+	}
+
+	metrics.Add("total requests", r.NumRequests)
+	metrics.Add("failed", r.Errors.SendStream)
+	if len(r.TopErrors) > 0 {
+		metrics.Add("server errors", r.TopErrors)
+	}
+
+	fmt.Println(metrics.Format(30))
+}


### PR DESCRIPTION
To capture server response bodies

Output looks like

```
transactions sent ............. 2066
transactions dropped .......... 90449
 - success % .................. 2.23
spans sent .................... 53945
spans dropped ................. 1793613
 - success % .................. 2.92
spans sent per transaction .... 26.11
errors sent ................... 4240
errors dropped ................ 126763
 - success % .................. 3.24
total events sent ............. 60251
 - per second ................. 5751.70
 - accepted ................... 43259
   - per second ............... 4129.60
   - success % ................ 71.80
failed ........................ 0
server errors ................. queue is full
```

fixes #58 