### PR TITLE
Fix -base-url flag error 'flag provided but not defined: -base-url'

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,4 @@ COPY --from=0 /build/hey-apm /hey-apm
 
 USER hey
 ENTRYPOINT ["/hey-apm"]
-CMD ["-base-url", "http://apm-server:8200/"]
+CMD ["-url", "http://apm-server:8200/"]


### PR DESCRIPTION
Missing update from https://github.com/elastic/hey-apm/pull/98 in the Dockerfile