### PR TITLE
ci: benchmark stage in the jenkins pipeline

### DIFF
--- a/.ci/jobs/apm-hey-test-mbp.yml
+++ b/.ci/jobs/apm-hey-test-mbp.yml
@@ -5,7 +5,7 @@
     description: APM Hey Tests
     project-type: multibranch
     view: APM-CI
-    concurrent: true
+    concurrent: false
     node: linux
     script-path: Jenkinsfile
     scm:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
   }
   parameters {
     string(name: 'GO_VERSION', defaultValue: "1.12.1", description: "Go version to use.")
-    string(name: 'APM_SERVER_VERSION', defaultValue: "7.3.0-SNAPSHOT", description: "APM Server Git branch/tag to use")
+    string(name: 'STACK_VERSION', defaultValue: "7.3.0-SNAPSHOT", description: "Stack version Git branch/tag to use")
   }
   stages {
     stage('Initializing'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,11 @@ pipeline {
               }
             }
           }
+          post {
+            always {
+              archiveArtifacts "${BASE_DIR}/build/environment.txt"
+            }
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,6 +107,7 @@ pipeline {
   }
 }
 
+// TODO: move to the shared library
 def sendBenchmark(String secretPath, Closure body) {
   def props = getVaultSecret(secret: secretPath)
   if(props?.errors){
@@ -130,4 +131,17 @@ def sendBenchmark(String secretPath, Closure body) {
         body()
     }
   }
+}
+
+def getProtocol(url){
+  def protocol = 'https://'
+  if(url.startsWith('https://')){
+    protocol = 'https://'
+  } else if (url.startsWith('http://')){
+    log(level: 'INFO', text: "Benchmarks: you are using 'http' protocol to access to the service.")
+    protocol = 'http://'
+  } else {
+    error 'sendBenchmark: unknow protocol, the url is not http(s).'
+  }
+  return protocol
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Run `./hey-apm -help` or see `main.go`
 
 The `Jenkinsfile` triggers sequentially:
 
-- `unit-test.sh`
+- `scripts/jenkins/unit-test.sh`
+- `scripts/jenkins/run-bench-in-docker.sh`
 
 ## Requirements
 - [gvm](https://github.com/andrewkroh/gvm)
@@ -51,6 +52,10 @@ Run `scripts/jenkins/run-bench-in-docker.sh`
 ## Configure the ES stack
 
 Run `ELASTIC_STACK=<version> scripts/jenkins/run-bench-in-docker.sh`
+
+## Configure the ES stack where to send the metrics to
+
+Run `ELASTIC_STACK=<version> ES_URL=<url> ES_USER=<user> ES_PASS=<password> scripts/jenkins/run-bench-in-docker.sh`
 
 # Known issues
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-hey-apm is a basic load generation tool for apm-server simulating different workloads. 
+hey-apm is a basic load generation tool for apm-server simulating different workloads.
 Back in the intake V1 days it was based on [hey](https://github.com/rakyll/hey),
 but now it uses the Go APM agent to generate events.
 
@@ -44,7 +44,15 @@ The `Jenkinsfile` triggers sequentially:
   ./scripts/jenkins/unit-test.sh 1.12.1
 ```
 
+# How to run locally the hey-apm using a docker-compose services
+
+Run `scripts/jenkins/run-bench-in-docker.sh`
+
+## Configure the ES stack
+
+Run `ELASTIC_STACK=<version> scripts/jenkins/run-bench-in-docker.sh`
+
 # Known issues
 
-* A single Go agent (as hey-apm uses) can't push enough load to overwhelm the apm-server, 
-as it will drop data too conservatively for benchmarking purposes. 
+* A single Go agent (as hey-apm uses) can't push enough load to overwhelm the apm-server,
+as it will drop data too conservatively for benchmarking purposes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,14 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+      validate-es-url:
+        condition: service_started
+
+  validate-es-url:
+    image: pstauffer/curl
+    command: curl -v ${ES_URL}
+    environment:
+      - ES_URL=${ES_URL}
 
 volumes:
   esdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,8 @@ services:
     working_dir: /app
     environment:
       - ES_URL=${ES_URL}
-      - ES_AUTH=${ES_AUTH}
+      - ES_USER=${ES_USER}
+      - ES_PASS=${ES_PASS}
     volumes:
       - ${PWD}:/app
     user: ${USER_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+version: "2.4"
+services:
+  apm-server:
+    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-8.0.0-SNAPSHOT}
+    ports:
+      - "127.0.0.1:8200:8200"
+      - "127.0.0.1:6060:6060"
+    command: >
+      apm-server -e
+        -E apm-server.expvar.enabled=true
+        -E apm-server.frontend.enabled=true
+        -E apm-server.frontend.rate_limit=100000
+        -E apm-server.host=0.0.0.0:8200
+        -E apm-server.read_timeout=1m
+        -E apm-server.shutdown_timeout=2m
+        -E apm-server.write_timeout=1m
+        -E setup.template.settings.index.number_of_replicas=0
+        -E xpack.monitoring.elasticsearch=true
+        -E output.elasticsearch.enabled=${APM_SERVER_ELASTICSEARCH_OUTPUT_ENABLED:-true}
+        -E output.elasticsearch.hosts=["elasticsearch:9200"]
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
+    logging:
+      driver: 'json-file'
+      options:
+          max-size: '2m'
+          max-file: '5'
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://apm-server:8200/healthcheck"]
+      retries: 10
+      interval: 10s
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-8.0.0-SNAPSHOT}
+    environment:
+      - bootstrap.memory_lock=true
+      - cluster.name=docker-cluster
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - discovery.type=single-node
+      - path.repo=/usr/share/elasticsearch/data/backups
+      - "ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g"
+      - "path.data=/usr/share/elasticsearch/data/${STACK_VERSION:-8.0.0-SNAPSHOT}"
+      - xpack.security.enabled=false
+      - xpack.license.self_generated.type=trial
+      - xpack.monitoring.collection.enabled=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 5g
+    logging:
+      driver: 'json-file'
+      options:
+          max-size: '2m'
+          max-file: '5'
+    ports:
+      - "127.0.0.1:9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      retries: 10
+      interval: 20s
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+
+  hey-apm:
+    build:
+      context: ./
+      dockerfile: docker/Dockerfile-bench
+    working_dir: /app
+    volumes:
+      - ${PWD}:/app
+    user: ${USER_ID}
+    depends_on:
+      apm-server:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+
+volumes:
+  esdata:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       context: ./
       dockerfile: docker/Dockerfile-bench
     working_dir: /app
+    command: >
+      /hey-apm -bench -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth "${ES_USER}:${ES_PASS}" -apm-es-url http://elasticsearch:9200
     environment:
       - ES_URL=${ES_URL}
       - ES_USER=${ES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
         -E setup.template.settings.index.number_of_replicas=0
         -E xpack.monitoring.elasticsearch=true
         -E output.elasticsearch.hosts=["elasticsearch:9200"]
+        -E apm-server.expvar.enabled=true
     cap_drop:
       - ALL
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,16 +7,8 @@ services:
       - "127.0.0.1:6060:6060"
     command: >
       apm-server -e
-        -E apm-server.expvar.enabled=true
-        -E apm-server.frontend.enabled=true
-        -E apm-server.frontend.rate_limit=100000
-        -E apm-server.host=0.0.0.0:8200
-        -E apm-server.read_timeout=1m
-        -E apm-server.shutdown_timeout=2m
-        -E apm-server.write_timeout=1m
         -E setup.template.settings.index.number_of_replicas=0
         -E xpack.monitoring.elasticsearch=true
-        -E output.elasticsearch.enabled=${APM_SERVER_ELASTICSEARCH_OUTPUT_ENABLED:-true}
         -E output.elasticsearch.hosts=["elasticsearch:9200"]
     cap_drop:
       - ALL
@@ -34,7 +26,7 @@ services:
       elasticsearch:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://apm-server:8200/healthcheck"]
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://apm-server:8200/"]
       retries: 10
       interval: 10s
 
@@ -46,7 +38,7 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       - discovery.type=single-node
       - path.repo=/usr/share/elasticsearch/data/backups
-      - "ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g"
+      - "ES_JAVA_OPTS=-XX:UseAVX=2 -Xms2g -Xmx4g"
       - "path.data=/usr/share/elasticsearch/data/${STACK_VERSION:-8.0.0-SNAPSHOT}"
       - xpack.security.enabled=false
       - xpack.license.self_generated.type=trial
@@ -55,7 +47,7 @@ services:
       memlock:
         soft: -1
         hard: -1
-    mem_limit: 5g
+    mem_limit: 6g
     logging:
       driver: 'json-file'
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.4"
+version: "2.1"
 services:
   apm-server:
     image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-8.0.0-SNAPSHOT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       dockerfile: docker/Dockerfile-bench
     working_dir: /app
     command: >
-      /hey-apm -bench -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth "${ES_USER}:${ES_PASS}" -apm-es-url http://elasticsearch:9200
+      /hey-apm -bench -run 5m -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth "${ES_USER}:${ES_PASS}" -apm-es-url http://elasticsearch:9200
     environment:
       - ES_URL=${ES_URL}
       - ES_USER=${ES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "2.1"
 services:
   apm-server:
     image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-8.0.0-SNAPSHOT}
+    container_name: apm-server
     ports:
       - "127.0.0.1:8200:8200"
       - "127.0.0.1:6060:6060"
@@ -33,6 +34,7 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-8.0.0-SNAPSHOT}
+    container_name: elasticsearch
     environment:
       - bootstrap.memory_lock=true
       - cluster.name=docker-cluster
@@ -70,6 +72,7 @@ services:
     working_dir: /app
     command: >
       /hey-apm -bench -run 5m -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth "${ES_USER}:${ES_PASS}" -apm-es-url http://elasticsearch:9200
+    container_name: hey-apm
     environment:
       - ES_URL=${ES_URL}
       - ES_USER=${ES_USER}
@@ -88,9 +91,12 @@ services:
 
   validate-es-url:
     image: pstauffer/curl
-    command: curl -v ${ES_URL}
+    command: curl --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
+    container_name: validate-es-url
     environment:
       - ES_URL=${ES_URL}
+      - ES_USER=${ES_USER}
+      - ES_PASS=${ES_PASS}
 
 volumes:
   esdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       - discovery.type=single-node
       - path.repo=/usr/share/elasticsearch/data/backups
-      - "ES_JAVA_OPTS=-XX:UseAVX=2 -Xms2g -Xmx4g"
+      - "ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx4g"
       - "path.data=/usr/share/elasticsearch/data/${STACK_VERSION:-8.0.0-SNAPSHOT}"
       - xpack.security.enabled=false
       - xpack.license.self_generated.type=trial
@@ -77,6 +77,7 @@ services:
     volumes:
       - ${PWD}:/app
     user: ${USER_ID}
+    mem_limit: 200m
     depends_on:
       apm-server:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,9 @@ services:
       context: ./
       dockerfile: docker/Dockerfile-bench
     working_dir: /app
+    environment:
+      - ES_URL=${ES_URL}
+      - ES_AUTH=${ES_AUTH}
     volumes:
       - ${PWD}:/app
     user: ${USER_ID}

--- a/docker/Dockerfile-bench
+++ b/docker/Dockerfile-bench
@@ -18,4 +18,4 @@ COPY --from=0 /build/hey-apm /hey-apm
 
 USER hey
 ENTRYPOINT ["/hey-apm"]
-CMD ["-bench", "-apm-url", "http://apm-server:8200", "-es-url", "${ES_URL}", "-es-auth", "${ES_AUTH}", "-apm-es-url", "http://elasticsearch:9200"]
+CMD ["-bench", "-apm-url", "http://apm-server:8200", "-es-url", "${ES_URL}", "-es-auth", "${ES_USER}:${ES_PASS}", "-apm-es-url", "http://elasticsearch:9200"]

--- a/docker/Dockerfile-bench
+++ b/docker/Dockerfile-bench
@@ -18,4 +18,4 @@ COPY --from=0 /build/hey-apm /hey-apm
 
 USER hey
 ENTRYPOINT ["/hey-apm"]
-CMD ["-bench", "-apm-url", "http://apm-server:8200", "-es-url", "http://elasticsearch:9200", "-apm-es-url", "http://elasticsearch:9200"]
+CMD ["-bench", "-apm-url", "http://apm-server:8200", "-es-url", "${ES_URL}", "-es-auth", "${ES_AUTH}", "-apm-es-url", "http://elasticsearch:9200"]

--- a/docker/Dockerfile-bench
+++ b/docker/Dockerfile-bench
@@ -1,0 +1,21 @@
+# from .. run: docker build -t hey-apm -f docker/Dockerfile .
+FROM golang:1.12
+RUN useradd hey
+
+WORKDIR /build
+COPY go.* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o hey-apm .
+
+FROM scratch
+MAINTAINER Elastic APM Team <docker@elastic.co>
+
+# https://github.com/golang/go/blob/release-branch.go1.12/src/crypto/x509/root_linux.go
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=0 /etc/passwd /etc/passwd
+COPY --from=0 /build/hey-apm /hey-apm
+
+USER hey
+ENTRYPOINT ["/hey-apm"]
+CMD ["-bench", "-run 5", "-apm-url", "http://apm-server:8200", "-es-url", "http://elasticsearch:9200", "-apm-es-url", "http://elasticsearch:9200"]

--- a/docker/Dockerfile-bench
+++ b/docker/Dockerfile-bench
@@ -18,4 +18,5 @@ COPY --from=0 /build/hey-apm /hey-apm
 
 USER hey
 ENTRYPOINT ["/hey-apm"]
-CMD ["-bench", "-apm-url", "http://apm-server:8200", "-es-url", "${ES_URL}", "-es-auth", "${ES_USER}:${ES_PASS}", "-apm-es-url", "http://elasticsearch:9200"]
+
+CMD ["sh", "-c", "-bench -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth ${ES_USER}:${ES_PASS} -apm-es-url http://elasticsearch:9200"]

--- a/docker/Dockerfile-bench
+++ b/docker/Dockerfile-bench
@@ -18,4 +18,4 @@ COPY --from=0 /build/hey-apm /hey-apm
 
 USER hey
 ENTRYPOINT ["/hey-apm"]
-CMD ["-bench", "-run 5", "-apm-url", "http://apm-server:8200", "-es-url", "http://elasticsearch:9200", "-apm-es-url", "http://elasticsearch:9200"]
+CMD ["-bench", "-apm-url", "http://apm-server:8200", "-es-url", "http://elasticsearch:9200", "-apm-es-url", "http://elasticsearch:9200"]

--- a/docker/Dockerfile-bench
+++ b/docker/Dockerfile-bench
@@ -15,8 +15,7 @@ MAINTAINER Elastic APM Team <docker@elastic.co>
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /etc/passwd /etc/passwd
 COPY --from=0 /build/hey-apm /hey-apm
-
 USER hey
 ENTRYPOINT ["/hey-apm"]
-
-CMD ["sh", "-c", "-bench -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth ${ES_USER}:${ES_PASS} -apm-es-url http://elasticsearch:9200"]
+## env variable interpolation does not work with arrays in docker. and sh is not available in the scratch image
+CMD -bench -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth ${ES_USER}:${ES_PASS} -apm-es-url http://elasticsearch:9200

--- a/docker/Dockerfile-bench
+++ b/docker/Dockerfile-bench
@@ -15,7 +15,5 @@ MAINTAINER Elastic APM Team <docker@elastic.co>
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=0 /etc/passwd /etc/passwd
 COPY --from=0 /build/hey-apm /hey-apm
+
 USER hey
-ENTRYPOINT ["/hey-apm"]
-## env variable interpolation does not work with arrays in docker. and sh is not available in the scratch image
-CMD -bench -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth ${ES_USER}:${ES_PASS} -apm-es-url http://elasticsearch:9200

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -6,7 +6,8 @@ docker-compose up --help
 
 STACK_VERSION=${STACK_VERSION} \
 ES_URL=${ES_URL} \
-ES_AUTH=${ES_AUTH} \
+ES_USER=${ES_USER} \
+ES_PASS=${ES_PASS} \
 USER_ID="$(id -u):$(id -g)" docker-compose \
   up \
   --no-color \

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -4,7 +4,10 @@ set -xeo pipefail
 docker-compose version
 docker-compose up --help
 
-STACK_VERSION=${STACK_VERSION} USER_ID="$(id -u):$(id -g)" docker-compose \
+STACK_VERSION=${STACK_VERSION} \
+ES_URL=${ES_URL} \
+ES_AUTH=${ES_AUTH} \
+USER_ID="$(id -u):$(id -g)" docker-compose \
   up \
   --no-color \
   --exit-code-from hey-apm \

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -5,6 +5,7 @@ function finish {
   set +e
   mkdir -p build
   {
+    echo "curl -v ${ES_URL}"
     docker-compose version
     docker system info
     docker ps -a
@@ -20,6 +21,7 @@ function finish {
 trap finish EXIT INT TERM
 
 ## Validate whether the ES_URL is reachable
+env | sort
 curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
 
 STACK_VERSION=${STACK_VERSION} \

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
-docker-compose version
-docker-compose up --help
+function finish {
+  echo "***********************************************************"
+  docker-compose version
+  docker-compose up --help
+  echo "***********************************************************"
+  docker ps -a
+  docker-compose logs
+}
+trap finish EXIT
 
 STACK_VERSION=${STACK_VERSION} \
 ES_URL=${ES_URL} \

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -1,27 +1,37 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
+USER_ID="$(id -u):$(id -g)"
+STACK_VERSION=${STACK_VERSION}
+ES_URL=${ES_URL}
+ES_USER=${ES_USER}
+ES_PASS=${ES_PASS}
+export USER_ID STACK_VERSION ES_URL ES_USER ES_PASS
+
 function finish {
+  set +e
   mkdir -p build
   {
     docker-compose version
     docker system info
     docker ps -a
-    docker-compose logs apm-server hey-apm elasticsearch wait
+    docker-compose logs apm-server elasticsearch validate-es-url hey-apm
+    docker inspect --format "{{json .State }}" apm-server elasticsearch validate-es-url hey-apm
   } > build/environment.txt
   docker-compose down -v
+  # To avoid running twice the same function and therefore override the environment.txt file.
+  trap - INT QUIT TERM EXIT
+  set -e
 }
+
 trap finish EXIT INT TERM
 
-STACK_VERSION=${STACK_VERSION} \
-ES_URL=${ES_URL} \
-ES_USER=${ES_USER} \
-ES_PASS=${ES_PASS} \
-USER_ID="$(id -u):$(id -g)" docker-compose \
-  up \
+## Validate whether the ES_URL is reachable
+curl --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
+
+docker-compose up \
   --no-color \
   --exit-code-from hey-apm \
-  --build \
   --remove-orphans \
   --abort-on-container-exit \
   hey-apm

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+STACK_VERSION=${STACK_VERSION} USER_ID="$(id -u):$(id -g)" docker-compose \
+  --no-ansi \
+  --log-level ERROR \
+  up \
+  --exit-code-from hey-apm \
+  --build \
+  --remove-orphans \
+  --abort-on-container-exit \
+  hey-apm
+
+docker-compose \
+  --no-ansi \
+  --log-level ERROR \
+  down -v

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
-USER_ID="$(id -u):$(id -g)"
-STACK_VERSION=${STACK_VERSION}
-ES_URL=${ES_URL}
-ES_USER=${ES_USER}
-ES_PASS=${ES_PASS}
-export USER_ID STACK_VERSION ES_URL ES_USER ES_PASS
-
 function finish {
   set +e
   mkdir -p build
@@ -27,11 +20,16 @@ function finish {
 trap finish EXIT INT TERM
 
 ## Validate whether the ES_URL is reachable
-curl --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
+curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
 
-docker-compose up \
+STACK_VERSION=${STACK_VERSION} \
+ES_URL=${ES_URL} \
+ES_USER=${ES_USER} \
+ES_PASS=${ES_PASS} \
+USER_ID="$(id -u):$(id -g)" docker-compose up \
   --no-color \
   --exit-code-from hey-apm \
+  --build \
   --remove-orphans \
   --abort-on-container-exit \
   hey-apm

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -9,7 +9,8 @@ function finish {
   docker system info
   echo "***********************************************************"
   docker ps -a
-  docker-compose logs
+  # list the services explicitly to report the logs by service for easy reading
+  docker-compose logs apm-server  hey-apm elasticsearch
 }
 trap finish EXIT
 

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -xeo pipefail
+
+docker-compose version
 
 STACK_VERSION=${STACK_VERSION} USER_ID="$(id -u):$(id -g)" docker-compose \
   --no-ansi \

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -6,6 +6,7 @@ docker-compose up --help
 
 STACK_VERSION=${STACK_VERSION} USER_ID="$(id -u):$(id -g)" docker-compose \
   up \
+  --no-color \
   --exit-code-from hey-apm \
   --build \
   --remove-orphans \

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -2,10 +2,9 @@
 set -xeo pipefail
 
 docker-compose version
+docker-compose up --help
 
 STACK_VERSION=${STACK_VERSION} USER_ID="$(id -u):$(id -g)" docker-compose \
-  --no-ansi \
-  --log-level ERROR \
   up \
   --exit-code-from hey-apm \
   --build \
@@ -13,7 +12,4 @@ STACK_VERSION=${STACK_VERSION} USER_ID="$(id -u):$(id -g)" docker-compose \
   --abort-on-container-exit \
   hey-apm
 
-docker-compose \
-  --no-ansi \
-  --log-level ERROR \
-  down -v
+docker-compose down -v

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -6,6 +6,7 @@ function finish {
   mkdir -p build
   {
     echo "curl -v ${ES_URL}"
+    curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
     docker-compose version
     docker system info
     docker ps -a

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -2,16 +2,14 @@
 set -xeo pipefail
 
 function finish {
+  mkdir -p build
+  {
+    docker-compose version
+    docker system info
+    docker ps -a
+    docker-compose logs apm-server hey-apm elasticsearch wait
+  } > build/environment.txt
   docker-compose down -v
-  echo "***********************************************************"
-  docker-compose version
-  docker-compose up --help
-  echo "***********************************************************"
-  docker system info
-  echo "***********************************************************"
-  docker ps -a
-  # list the services explicitly to report the logs by service for easy reading
-  docker-compose logs apm-server  hey-apm elasticsearch
 }
 trap finish EXIT INT TERM
 

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -2,6 +2,7 @@
 set -xeo pipefail
 
 function finish {
+  docker-compose down -v
   echo "***********************************************************"
   docker-compose version
   docker-compose up --help
@@ -12,7 +13,7 @@ function finish {
   # list the services explicitly to report the logs by service for easy reading
   docker-compose logs apm-server  hey-apm elasticsearch
 }
-trap finish EXIT
+trap finish EXIT INT TERM
 
 STACK_VERSION=${STACK_VERSION} \
 ES_URL=${ES_URL} \
@@ -26,5 +27,3 @@ USER_ID="$(id -u):$(id -g)" docker-compose \
   --remove-orphans \
   --abort-on-container-exit \
   hey-apm
-
-docker-compose down -v

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -6,6 +6,8 @@ function finish {
   docker-compose version
   docker-compose up --help
   echo "***********************************************************"
+  docker system info
+  echo "***********************************************************"
   docker ps -a
   docker-compose logs
 }

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -5,8 +5,10 @@ function finish {
   set +e
   mkdir -p build
   {
-    echo "curl -v ${ES_URL}"
+    echo "curl -v --user *****:**** ${ES_URL}"
     curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
+    echo "curl -v ${ES_URL}"
+    curl -v "${ES_URL}" 2>&1
     docker-compose version
     docker system info
     docker ps -a

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -5,10 +5,6 @@ function finish {
   set +e
   mkdir -p build
   {
-    echo "curl -v --user *****:**** ${ES_URL}"
-    curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
-    echo "curl -v ${ES_URL}"
-    curl -v "${ES_URL}" 2>&1
     docker-compose version
     docker system info
     docker ps -a
@@ -24,7 +20,6 @@ function finish {
 trap finish EXIT INT TERM
 
 ## Validate whether the ES_URL is reachable
-env | sort
 curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
 
 STACK_VERSION=${STACK_VERSION} \


### PR DESCRIPTION
fixes https://github.com/elastic/hey-apm/issues/119

## Highlights
- Enable benchmark stage in the Jenkins pipeline.
- First iteration using Docker Compose to prepare the context and run the benchmarking.

## Tasks
- [x] What data is required to be exported?
- [x] `-run 5m` doesn't see to work
- [x] Do we want to export the data to `https://apm-agent-benchmarks.app.elstc.co` or somewhere else?
- [x] Move `sendBenchmark` method to the apm pipeline library.

## Test cases
- [build](https://apm-ci.elastic.co/job/apm-server/job/apm-hey-test-mbp/view/change-requests/job/PR-125/7/) took 10 minutes to run in the bare-metal.
- [benchmark](https://apm-ci.elastic.co/job/apm-server/job/apm-hey-test-mbp/view/change-requests/job/PR-125/42/) took 38 minutes to run in the bare-metal using the docker-compose.
