### PR TITLE
ci: uses another ES benchmark cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     APM_SERVER_VERSION = "${params.APM_SERVER_VERSION}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    BENCHMARK_SECRET  = 'secret/apm-team/ci/apm-server-benchmark-cloud'
+    BENCHMARK_SECRET  = 'secret/apm-team/ci/java-agent-benchmark-cloud'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,10 @@ pipeline {
         */
         stage('Benchmark') {
           agent { label 'metal' }
+          when {
+            beforeAgent true
+            not { changeRequest() }
+          }
           steps {
             withGithubNotify(context: 'Benchmark', tab: 'tests') {
               deleteDir()


### PR DESCRIPTION
As already discussed offline, let's use another ES cluster to send the benchmarks