### PR TITLE
ci: specific pipeline to run the benchmarking

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,109 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent any
+  environment {
+    BASE_DIR="src/github.com/elastic/hey-apm"
+    JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
+    GO_VERSION = "${params.GO_VERSION}"
+    STACK_VERSION = "${params.STACK_VERSION}"
+    NOTIFY_TO = credentials('notify-to')
+    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    BENCHMARK_SECRET  = 'secret/apm-team/ci/apm-server-benchmark-cloud'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  parameters {
+    string(name: 'GO_VERSION', defaultValue: "1.12.1", description: "Go version to use.")
+    string(name: 'STACK_VERSION', defaultValue: "7.3.0-SNAPSHOT", description: "Stack version Git branch/tag to use")
+  }
+  stages {
+    stage('Initializing'){
+      agent { label 'linux && immutable' }
+      options { skipDefaultCheckout() }
+      environment {
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+        HOME = "${env.WORKSPACE}"
+        GOPATH = "${env.WORKSPACE}"
+      }
+      stages {
+        /**
+         Checkout the code and stash it, to use it on other stages.
+        */
+        stage('Checkout') {
+          steps {
+            deleteDir()
+            gitCheckout(basedir: "${BASE_DIR}")
+            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+          }
+        }
+        /**
+          Unit tests.
+        */
+        stage('Test') {
+          steps {
+            withGithubNotify(context: 'Test', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh "./scripts/jenkins/unit-test.sh ${GO_VERSION}"
+              }
+            }
+          }
+          post {
+            always {
+              coverageReport("${BASE_DIR}/build/coverage")
+              junit(allowEmptyResults: true,
+                keepLongStdio: true,
+                testResults: "${BASE_DIR}/build/*.xml")
+            }
+          }
+        }
+        /**
+          APM server benchmark.
+        */
+        stage('Benchmark') {
+          agent { label 'metal' }
+          when {
+            beforeAgent true
+            not { changeRequest() } }
+          }
+          steps {
+            withGithubNotify(context: 'Benchmark', tab: 'tests') {
+              deleteDir()
+              unstash 'source'
+              script {
+                dir(BASE_DIR){
+                  sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
+                                               user_var: 'ES_USER', pass_var: 'ES_PASS') {
+                    sh 'scripts/jenkins/run-bench-in-docker.sh'
+                  }
+                }
+              }
+            }
+          }
+          post {
+            always {
+              archiveArtifacts "${BASE_DIR}/build/environment.txt"
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -8,10 +8,8 @@ pipeline {
     BASE_DIR="src/github.com/elastic/hey-apm"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     GO_VERSION = "${params.GO_VERSION}"
-    STACK_VERSION = "${params.STACK_VERSION}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    BENCHMARK_SECRET  = 'secret/apm-team/ci/java-agent-benchmark-cloud'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -25,7 +23,6 @@ pipeline {
   }
   parameters {
     string(name: 'GO_VERSION', defaultValue: "1.12.1", description: "Go version to use.")
-    string(name: 'STACK_VERSION', defaultValue: "7.3.0-SNAPSHOT", description: "Stack version Git branch/tag to use")
   }
   stages {
     stage('Initializing'){
@@ -66,35 +63,6 @@ pipeline {
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
                 testResults: "${BASE_DIR}/build/*.xml")
-            }
-          }
-        }
-        /**
-          APM server benchmark.
-        */
-        stage('Benchmark') {
-          agent { label 'metal' }
-          when {
-            beforeAgent true
-            not { changeRequest() }
-          }
-          steps {
-            withGithubNotify(context: 'Benchmark', tab: 'tests') {
-              deleteDir()
-              unstash 'source'
-              script {
-                dir(BASE_DIR){
-                  sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
-                                               user_var: 'ES_USER', pass_var: 'ES_PASS') {
-                    sh 'scripts/jenkins/run-bench-in-docker.sh'
-                  }
-                }
-              }
-            }
-          }
-          post {
-            always {
-              archiveArtifacts "${BASE_DIR}/build/environment.txt"
             }
           }
         }

--- a/.ci/jobs/apm-hey-test-benchmark.yml
+++ b/.ci/jobs/apm-hey-test-benchmark.yml
@@ -1,0 +1,22 @@
+---
+- job:
+    name: apm-server/apm-hey-test-benchmark
+    display-name: Hey apm test benchmark pipeline scheduled daily
+    description: Hey apm test benchmark pipeline scheduled daily from Monday to Friday
+    view: APM-CI
+    project-type: pipeline
+    pipeline-scm:
+      script-path: .ci/scheduled-benchmark.groovy
+      scm:
+      - git:
+          url: git@github.com:elastic/hey-apm.git
+          refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+          wipe-workspace: 'True'
+          name: origin
+          shallow-clone: true
+          credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          reference-repo: /var/lib/jenkins/.git-references/hey-apm.git
+          branches:
+          - master
+    triggers:
+    - timed: 'H H(3-5) * * 1-5'

--- a/.ci/jobs/apm-hey-test-mbp.yml
+++ b/.ci/jobs/apm-hey-test-mbp.yml
@@ -10,7 +10,7 @@
     script-path: .ci/Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current

--- a/.ci/jobs/apm-hey-test-mbp.yml
+++ b/.ci/jobs/apm-hey-test-mbp.yml
@@ -7,7 +7,7 @@
     view: APM-CI
     concurrent: false
     node: linux
-    script-path: Jenkinsfile
+    script-path: .ci/Jenkinsfile
     scm:
     - github:
         branch-discovery: all

--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -26,7 +26,7 @@ pipeline {
     STACK_VERSION = "${params.STACK_VERSION}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    BENCHMARK_SECRET  = 'secret/apm-team/ci/apm-server-benchmark-cloud'
+    BENCHMARK_SECRET  = 'secret/apm-team/ci/java-agent-benchmark-cloud'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -64,7 +64,7 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
               if (params.STACK_VERSION.trim()) {
-                env.STACK_VERSION = getVersion()
+                env.STACK_VERSION = getVersion() + '-SNAPSHOT'
               }
             }
           }

--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -1,4 +1,19 @@
-#!/usr/bin/env groovy
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 @Library('apm@current') _
 
@@ -6,10 +21,9 @@ pipeline {
   agent any
   environment {
     BASE_DIR="src/github.com/elastic/hey-apm"
-    APM_SERVER_BASE_DIR = "src/github.com/elastic/apm-server"
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     GO_VERSION = "${params.GO_VERSION}"
-    APM_SERVER_VERSION = "${params.APM_SERVER_VERSION}"
+    STACK_VERSION = "${params.STACK_VERSION}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     BENCHMARK_SECRET  = 'secret/apm-team/ci/apm-server-benchmark-cloud'
@@ -21,8 +35,6 @@ pipeline {
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
-    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
-    quietPeriod(10)
   }
   triggers {
     cron('H H(3-5) * * 1-5')

--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -1,19 +1,4 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+#!/usr/bin/env groovy
 
 @Library('apm@current') _
 


### PR DESCRIPTION
## Highlights
- Create a pipeline to be triggered only on a daily basis for the master branch. Will run the benchmark.
- Change multibranch pipeline to validate PRs but won't run on a daily basis and won't trigger the benchmark.
- Mutlibranch pipeline will validate the benchmark only for the branches.

## Workflows
- Single pipeline to validate the benchmark on daily basis for the master branch.
- Multibranch pipeline to validate each PR without running the benchmark tests. Based on GitHub push events.
- Multibranch pipeline to validate each branch in the origin by running the UTs and the benchmark. Based on GitHub push events.

## Test Cases
- Validated locally running the JJBB with the same docker imaged used by infra for the apm-ci, although we some tweaks to run the https service locally.

Depends on https://github.com/elastic/hey-apm/pull/128