### PR TITLE
[apm-ci] run CI everyday

### DIFF
--- a/.ci/jobs/apm-hey-test-benchmark.yml
+++ b/.ci/jobs/apm-hey-test-benchmark.yml
@@ -19,4 +19,4 @@
           branches:
           - master
     triggers:
-    - timed: 'H H(3-5) * * 1-5'
+    - timed: 'H H(3-5) * * *'

--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -23,7 +23,7 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   triggers {
-    cron('H H(3-5) * * 1-5')
+    cron('H H(3-5) * * *')
   }
   parameters {
     string(name: 'GO_VERSION', defaultValue: '1.12.1', description: 'Go version to use.')


### PR DESCRIPTION
Reasons:

- Weekend variations should be 0, but actual observed variations should serve as a baseline to determine impact of network (after #136), noisy neighbours (if any) or other effects.

- Some people might work on weekends (eg. shifting days) 

- Dashboards look nicer without gaps :)