### PR TITLE
ci(jenkins): enable new ES cluster for benchmarking

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     GO_VERSION = "${params.GO_VERSION}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -64,30 +63,6 @@ pipeline {
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
                 testResults: "${BASE_DIR}/build/*.xml")
-            }
-          }
-        }
-        /**
-          APM server benchmark.
-        */
-        stage('Benchmark') {
-          agent { label 'metal' }
-          options { skipDefaultCheckout() }
-          steps {
-            deleteDir()
-            unstash 'source'
-            script {
-              dir(BASE_DIR){
-                sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
-                                             user_var: 'ES_USER', pass_var: 'ES_PASS') {
-                  sh 'scripts/jenkins/run-bench-in-docker.sh'
-                }
-              }
-            }
-          }
-          post {
-            always {
-              archiveArtifacts "${BASE_DIR}/build/environment.txt"
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -72,6 +72,7 @@ pipeline {
         */
         stage('Benchmark') {
           agent { label 'metal' }
+          options { skipDefaultCheckout() }
           steps {
             deleteDir()
             unstash 'source'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
     GO_VERSION = "${params.GO_VERSION}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
+    BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -63,6 +64,29 @@ pipeline {
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
                 testResults: "${BASE_DIR}/build/*.xml")
+            }
+          }
+        }
+        /**
+          APM server benchmark.
+        */
+        stage('Benchmark') {
+          agent { label 'metal' }
+          steps {
+            deleteDir()
+            unstash 'source'
+            script {
+              dir(BASE_DIR){
+                sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
+                                             user_var: 'ES_USER', pass_var: 'ES_PASS') {
+                  sh 'scripts/jenkins/run-bench-in-docker.sh'
+                }
+              }
+            }
+          }
+          post {
+            always {
+              archiveArtifacts "${BASE_DIR}/build/environment.txt"
             }
           }
         }

--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -12,7 +12,7 @@ pipeline {
     STACK_VERSION = "${params.STACK_VERSION}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
-    BENCHMARK_SECRET  = 'secret/apm-team/ci/java-agent-benchmark-cloud'
+    BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         -E setup.template.settings.index.number_of_replicas=0
         -E xpack.monitoring.elasticsearch=true
         -E apm-server.expvar.enabled=true
+        -E apm-server.ilm.enabled=false
         -E output.elasticsearch.hosts=["${ES_URL}"]
         -E output.elasticsearch.username=${ES_USER}
         -E output.elasticsearch.password=${ES_PASS}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,10 @@ services:
       apm-server -e
         -E setup.template.settings.index.number_of_replicas=0
         -E xpack.monitoring.elasticsearch=true
-        -E output.elasticsearch.hosts=["elasticsearch:9200"]
+        -E output.elasticsearch.hosts=["${ES_URL}"]
         -E apm-server.expvar.enabled=true
+    environment:
+      - ES_URL=${ES_URL}
     cap_drop:
       - ALL
     cap_add:
@@ -24,46 +26,10 @@ services:
       options:
           max-size: '2m'
           max-file: '5'
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://apm-server:8200/"]
       retries: 10
       interval: 10s
-
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-8.0.0-SNAPSHOT}
-    container_name: elasticsearch
-    environment:
-      - bootstrap.memory_lock=true
-      - cluster.name=docker-cluster
-      - cluster.routing.allocation.disk.threshold_enabled=false
-      - discovery.type=single-node
-      - path.repo=/usr/share/elasticsearch/data/backups
-      - "ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx4g"
-      - "path.data=/usr/share/elasticsearch/data/${STACK_VERSION:-8.0.0-SNAPSHOT}"
-      - xpack.security.enabled=false
-      - xpack.license.self_generated.type=trial
-      - xpack.monitoring.collection.enabled=true
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    mem_limit: 6g
-    logging:
-      driver: 'json-file'
-      options:
-          max-size: '2m'
-          max-file: '5'
-    ports:
-      - "127.0.0.1:9200:9200"
-    healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
-      retries: 10
-      interval: 20s
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
 
   hey-apm:
     build:
@@ -71,7 +37,7 @@ services:
       dockerfile: docker/Dockerfile-bench
     working_dir: /app
     command: >
-      /hey-apm -bench -run 5m -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth "${ES_USER}:${ES_PASS}" -apm-es-url http://elasticsearch:9200
+      /hey-apm -bench -run 5m -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth "${ES_USER}:${ES_PASS}" -apm-es-url ${ES_URL} -apm-es-auth "${ES_USER}:${ES_PASS}"
     container_name: hey-apm
     environment:
       - ES_URL=${ES_URL}
@@ -83,8 +49,6 @@ services:
     mem_limit: 200m
     depends_on:
       apm-server:
-        condition: service_healthy
-      elasticsearch:
         condition: service_healthy
       validate-es-url:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,14 @@ services:
       apm-server -e
         -E setup.template.settings.index.number_of_replicas=0
         -E xpack.monitoring.elasticsearch=true
-        -E output.elasticsearch.hosts=["${ES_URL}"]
         -E apm-server.expvar.enabled=true
+        -E output.elasticsearch.hosts=["${ES_URL}"]
+        -E output.elasticsearch.username=${ES_USER}
+        -E output.elasticsearch.password=${ES_PASS}
     environment:
       - ES_URL=${ES_URL}
+      - ES_USER=${ES_USER}
+      - ES_PASS=${ES_PASS}
     cap_drop:
       - ALL
     cap_add:

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -11,6 +11,9 @@ function finish {
     docker-compose logs apm-server validate-es-url hey-apm
     docker inspect --format "{{json .State }}" apm-server validate-es-url hey-apm
   } > build/environment.txt
+  # Ensure all the sensitive details are obfuscated
+  sed -i.bck -e "s#${ES_USER}#********#g" -e "s#${ES_PASS}#********#g" -e "s#${ES_URL}#********#g" build/environment.txt
+  rm build/*.bck || true
   docker-compose down -v
   # To avoid running twice the same function and therefore override the environment.txt file.
   trap - INT QUIT TERM EXIT
@@ -23,7 +26,7 @@ trap finish EXIT INT TERM
 curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
 
 ## Report ES stack health
-curl --user "${ES_USER}:${ES_PASS}" "${ES_URL}/_cluster/health"
+curl -s --user "${ES_USER}:${ES_PASS}" "${ES_URL}/_cluster/health"
 
 STACK_VERSION=${STACK_VERSION} \
 ES_URL=${ES_URL} \

--- a/scripts/jenkins/run-bench-in-docker.sh
+++ b/scripts/jenkins/run-bench-in-docker.sh
@@ -8,8 +8,8 @@ function finish {
     docker-compose version
     docker system info
     docker ps -a
-    docker-compose logs apm-server elasticsearch validate-es-url hey-apm
-    docker inspect --format "{{json .State }}" apm-server elasticsearch validate-es-url hey-apm
+    docker-compose logs apm-server validate-es-url hey-apm
+    docker inspect --format "{{json .State }}" apm-server validate-es-url hey-apm
   } > build/environment.txt
   docker-compose down -v
   # To avoid running twice the same function and therefore override the environment.txt file.
@@ -21,6 +21,9 @@ trap finish EXIT INT TERM
 
 ## Validate whether the ES_URL is reachable
 curl -v --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
+
+## Report ES stack health
+curl --user "${ES_USER}:${ES_PASS}" "${ES_URL}/_cluster/health"
 
 STACK_VERSION=${STACK_VERSION} \
 ES_URL=${ES_URL} \


### PR DESCRIPTION
Closes https://github.com/elastic/hey-apm/issues/136

## Highlights
- Use new ES cluster to store the benchmarking results
- Granted privileges for the roles: `apm_system` and `ingest_admin`
- Disable `ilm` since `7.3` ES seems to prompt the below logs`action [cluster:admin/ilm/get] is unauthorized`

## Tasks
- [x] Use the new ES for running the benchmarking
- [x] Revert changes in .ci/Jenkinsfile which were only for speeding up the tests in the CI.