### PR TITLE
Add git reference repo to CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
         stage('Checkout') {
           steps {
             deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}")
+            gitCheckout(basedir: "${BASE_DIR}", reference: '/var/lib/jenkins/.git-references/hey-apm.git')
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }

--- a/.ci/jobs/apm-hey-test-mbp.yml
+++ b/.ci/jobs/apm-hey-test-mbp.yml
@@ -39,6 +39,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/hey-apm.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'


### PR DESCRIPTION
## What does this PR do?

Adds reference repos.

These correspond to repos and download locations which can be seen in [the Jenkins job which mirrors them](https://apm-ci.elastic.co/job/jenkins-git-fetch-reference/).

## Why is it important?

Makes for more efficient git checkouts.

## Related issues
Refs a private repo