### PR TITLE
Update the wait group counter before pushing to the channel.

### DIFF
--- a/agent/tracer.go
+++ b/agent/tracer.go
@@ -110,8 +110,8 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	b, rerr := ioutil.ReadAll(resp.Body)
 	if rerr == nil {
-		rt.c <- b
 		rt.wg.Add(1)
+		rt.c <- b
 		resp.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
 


### PR DESCRIPTION
Fixes a rare panic: sync: negative WaitGroup counter.
Credits to @axw for pointing it out.