### PR TITLE
ci(jenkins): customise the apm-server

### DIFF
--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -9,6 +9,7 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     GO_VERSION = "${params.GO_VERSION}"
     STACK_VERSION = "${params.STACK_VERSION}"
+    APM_DOCKER_IMAGE = "${params.APM_DOCKER_IMAGE}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
@@ -26,7 +27,8 @@ pipeline {
   }
   parameters {
     string(name: 'GO_VERSION', defaultValue: '1.12.1', description: 'Go version to use.')
-    string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version Git branch/tag to use. Default behavior uses the apm-server@master version.')
+    string(name: 'STACK_VERSION', defaultValue: '8.0.0-SNAPSHOT', description: 'Stack version Git branch/tag to use.')
+    string(name: 'APM_DOCKER_IMAGE', defaultValue: 'docker.elastic.co/apm/apm-server', description: 'The docker image to be used.')
   }
   stages {
     stage('Initializing'){

--- a/.ci/scheduled-benchmark.groovy
+++ b/.ci/scheduled-benchmark.groovy
@@ -82,7 +82,7 @@ pipeline {
             script {
               dir(BASE_DIR){
                 sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
-                                            user_var: 'ES_USER', pass_var: 'ES_PASS') {
+                                             user_var: 'ES_USER', pass_var: 'ES_PASS') {
                   sh '.ci/scripts/run-bench-in-docker.sh'
                 }
               }

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ The `Jenkinsfile` triggers sequentially:
 
 Run `.ci/scripts/run-bench-in-docker.sh`
 
-## Configure the ES stack
+## Configure the ES stack version
 
 Run `ELASTIC_STACK=<version> .ci/scripts/run-bench-in-docker.sh`
+
+## Configure the docker image for the ES stack
+
+Run `APM_DOCKER_IMAGE=<docker-image> .ci/scripts/run-bench-in-docker.sh`
 
 ## Configure the ES stack where to send the metrics to
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   apm-server:
-    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-8.0.0-SNAPSHOT}
+    image: ${APM_DOCKER_IMAGE:-docker.elastic.co/apm/apm-server}:${STACK_VERSION:-8.0.0-SNAPSHOT}
     container_name: apm-server
     ports:
       - "127.0.0.1:8200:8200"


### PR DESCRIPTION
### What 

This will help to specify what version and docker image from the `apm-server` to be used when running the hey-apm

### Issues

Caused by https://github.com/elastic/hey-apm/issues/146