### PR TITLE
Wait for libbeat pipeline to drain

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -53,6 +53,11 @@ type Cmdline []string
 type ExpvarMetrics struct {
 	Cmdline  Cmdline  `json:"cmdline"`
 	Memstats Memstats `json:"memstats"`
+	LibbeatMetrics
+}
+
+type LibbeatMetrics struct {
+	PipelineEventsActive *int64 `json:"libbeat.pipeline.events.active"`
 }
 
 type Memstats struct {


### PR DESCRIPTION
After a load test, wait for the APM Server's libbeat pipeline to be emptied of active events. This should help to avoid the effects of one load test spilling over into the next.

Relies on https://github.com/elastic/apm-server/pull/3550