### PR TITLE
docker-compose: enable CPU and heap profiling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
         -E apm-server.expvar.enabled=true
         -E apm-server.ilm.enabled=false
         -E apm-server.instrumentation.enabled=true
+        -E apm-server.instrumentation.profiling.heap.enabled=true
+        -E apm-server.instrumentation.profiling.cpu.enabled=true
         -E output.elasticsearch.hosts=["${ES_URL}"]
         -E output.elasticsearch.username=${ES_USER}
         -E output.elasticsearch.password=${ES_PASS}


### PR DESCRIPTION
Enable continuous profiling of the apm-server under load.

Closes #156 