### PR TITLE
Revert "docker-compose: enable CPU and heap profiling (#165)"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
         -E apm-server.expvar.enabled=true
         -E apm-server.ilm.enabled=false
         -E apm-server.instrumentation.enabled=true
-        -E apm-server.instrumentation.profiling.heap.enabled=true
-        -E apm-server.instrumentation.profiling.cpu.enabled=true
         -E output.elasticsearch.hosts=["${ES_URL}"]
         -E output.elasticsearch.username=${ES_USER}
         -E output.elasticsearch.password=${ES_PASS}


### PR DESCRIPTION
This reverts commit 5c9baf7a567f9bac8cd1cd00c8801c06d34eb353.

It appears that the introduction of profiling is interfering with benchmarks, causing "queue is full" errors. We could increase `queue.mem.events`, but there will still be interference. I think a better approach would be to configure the apm-server under load to send its events/metrics/profiles to a separate apm-server, to minimise interference.