### PR TITLE
Keep self instrumentation

### DIFF
--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -31,6 +31,11 @@ func Run(input models.Input) error {
 		return errors.Wrap(err, "Elasticsearch not reachable, won't be able to index a report")
 	}
 
+	if err == nil {
+		fmt.Println("deleting previous APM indices...")
+		err = es.DeleteAPMIndices(conn)
+	}
+
 	warmUp(input)
 
 	run := runner(conn, input.RegressionMargin, input.RegressionDays)
@@ -63,10 +68,6 @@ func Run(input models.Input) error {
 		WithFrames(50).
 		Input)
 
-	if err == nil {
-		fmt.Println("deleting APM indices...")
-		err = es.DeleteAPMIndices(conn)
-	}
 	return err
 }
 

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -75,7 +75,7 @@ func runner(conn es.Connection, margin float64, days string) func(name string, i
 	var err error
 	return func(name string, input models.Input) error {
 		fmt.Println("running benchmark with " + name)
-		report, e := worker.Run(input)
+		report, e := worker.Run(input, name)
 		if e == nil {
 			e = verify(conn, report, margin, days)
 		}
@@ -93,7 +93,7 @@ func warmUp(input models.Input) {
 	input.RunTimeout = warm
 	input.SkipIndexReport = true
 	fmt.Println(fmt.Sprintf("warming up %.1f seconds...", warm.Seconds()))
-	worker.Run(input)
+	worker.Run(input, "warm up")
 	coolDown()
 }
 

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -64,8 +64,8 @@ func Run(input models.Input) error {
 		Input)
 
 	if err == nil {
-		fmt.Println("deleting apm-* indices...")
-		err = es.Delete(conn, "apm-*")
+		fmt.Println("deleting APM indices...")
+		err = es.DeleteAPMIndices(conn)
 	}
 	return err
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         -E monitoring.enabled=true
         -E apm-server.expvar.enabled=true
         -E apm-server.ilm.enabled=false
-        -E apm-server.instrumentation.enabled=false
+        -E apm-server.instrumentation.enabled=true
         -E output.elasticsearch.hosts=["${ES_URL}"]
         -E output.elasticsearch.username=${ES_USER}
         -E output.elasticsearch.password=${ES_PASS}

--- a/es/api.go
+++ b/es/api.go
@@ -104,7 +104,22 @@ func Count(conn Connection, index string) uint64 {
 }
 
 func Delete(conn Connection, indices ...string) error {
-	resp, err := conn.Indices.Delete(indices)
+	body := map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"must_not": []map[string]interface{}{
+					{
+						"term": map[string]interface{}{
+							"service.name": map[string]interface{}{
+								"value": "apm-server",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	resp, err := conn.DeleteByQuery(indices, esutil.NewJSONReader(body))
 	if err != nil {
 		return err
 	}

--- a/es/api.go
+++ b/es/api.go
@@ -3,10 +3,8 @@ package es
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/elastic/go-elasticsearch/v7/esutil"
-
 	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esutil"
 	"github.com/elastic/hey-apm/models"
 	"github.com/elastic/hey-apm/strcoll"
 	"github.com/pkg/errors"
@@ -103,7 +101,7 @@ func Count(conn Connection, index string) uint64 {
 	return 0
 }
 
-func Delete(conn Connection, indices ...string) error {
+func DeleteAPMIndices(conn Connection) error {
 	body := map[string]interface{}{
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{
@@ -119,7 +117,7 @@ func Delete(conn Connection, indices ...string) error {
 			},
 		},
 	}
-	resp, err := conn.DeleteByQuery(indices, esutil.NewJSONReader(body))
+	resp, err := conn.DeleteByQuery([]string{"apm*"}, esutil.NewJSONReader(body))
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func runWorkers(input models.Input) {
 			randomDelay := time.Duration(rand.Intn(input.DelayMillis)) * time.Millisecond
 			fmt.Println(fmt.Sprintf("--- Starting instance (%v) in %v milliseconds", idx, randomDelay))
 			time.Sleep(randomDelay)
-			if _, err := worker.Run(input); err != nil {
+			if _, err := worker.Run(input, ""); err != nil {
 				os.Exit(1)
 			}
 		}()

--- a/models/report.go
+++ b/models/report.go
@@ -24,7 +24,8 @@ type Report struct {
 	Timestamp time.Time `json:"@timestamp"`
 	// any arbitrary strings set by the user, meant to filter results
 	Labels []string `json:"labels, omitempty"`
-
+	// name of the test run
+	TestName string `json:"test_name, omitempty"`
 	// apm-server release version or build sha
 	ApmVersion string `json:"apm_version,omitempty"`
 	// commit SHA

--- a/worker/run.go
+++ b/worker/run.go
@@ -19,7 +19,7 @@ const quiesceTimeout = 5 * time.Minute
 
 // Run executes a load test work with the given input, prints the results,
 // indexes a performance report, and returns it along any error.
-func Run(input models.Input) (models.Report, error) {
+func Run(input models.Input, testName string) (models.Report, error) {
 	testNode, err := es.NewConnection(input.ApmElasticsearchUrl, input.ApmElasticsearchAuth)
 	if err != nil {
 		return models.Report{}, errors.Wrap(err, "Elasticsearch used by APM Server not known or reachable")
@@ -60,7 +60,7 @@ func Run(input models.Input) (models.Report, error) {
 		logger.Printf("waiting for %d active events to be processed", *activeEvents)
 		time.Sleep(time.Second)
 	}
-	report := createReport(input, result, initialStatus, finalStatus)
+	report := createReport(input, testName, result, initialStatus, finalStatus)
 
 	if input.SkipIndexReport {
 		return report, err
@@ -100,7 +100,7 @@ func prepareWork(input models.Input) (worker, error) {
 	return w, nil
 }
 
-func createReport(input models.Input, result Result, initialStatus, finalStatus server.Status) models.Report {
+func createReport(input models.Input, testName string, result Result, initialStatus, finalStatus server.Status) models.Report {
 	this, _ := os.Hostname()
 	r := models.Report{
 		Input: input,
@@ -108,6 +108,7 @@ func createReport(input models.Input, result Result, initialStatus, finalStatus 
 		ReportId:     shortId(),
 		ReportDate:   time.Now().Format(models.GITRFC),
 		ReporterHost: this,
+		TestName:     testName,
 
 		Timestamp: time.Now(),
 		Elapsed:   result.Flushed.Sub(result.Start).Seconds(),


### PR DESCRIPTION
* Re-enables self instrumentation
* Removes all apm indices except the ones from apm-server itself
* Moves the removal to happen before the test runs
* Adds a "test name" field to the test reports