### PR TITLE
agent/tracer cleanup

### DIFF
--- a/agent/tracer.go
+++ b/agent/tracer.go
@@ -9,16 +9,19 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/hey-apm/conv"
-	"github.com/elastic/hey-apm/strcoll"
-
 	"go.elastic.co/apm"
 	apmtransport "go.elastic.co/apm/transport"
 )
 
 type Tracer struct {
 	*apm.Tracer
-	TransportStats *TransportStats
+	roundTripper *roundTripperWrapper
+}
+
+func (t *Tracer) TransportStats() TransportStats {
+	t.roundTripper.statsMu.RLock()
+	defer t.roundTripper.statsMu.RUnlock()
+	return t.roundTripper.stats
 }
 
 // TransportStats are captured by reading apm-server responses.
@@ -28,74 +31,59 @@ type TransportStats struct {
 	NumRequests    uint64
 }
 
-func (t Tracer) Close() {
-	t.Tracer.Close()
-	rt := t.Transport.(*apmtransport.HTTPTransport).Client.Transport.(*roundTripperWrapper)
-	rt.wg.Wait()
-	close(rt.c)
-}
-
 // NewTracer returns a wrapper with a new Go agent instance and its transport stats.
-func NewTracer(logger apm.Logger, serverUrl, serverSecret, apiKey, serviceName string, maxSpans int) (*Tracer, error) {
-	// version can be set with ELASTIC_APM_SERVICE_VERSION
-	// ensure that apmtracer instances do not share the same apmtransport instace
-	defaultTransport, err := apmtransport.InitDefault()
+func NewTracer(
+	logger apm.Logger,
+	serverURL, serverSecret, apiKey, serviceName string,
+	maxSpans int,
+) (*Tracer, error) {
+
+	// Ensure that each tracer uses an independent transport.
+	transport, err := apmtransport.NewHTTPTransport()
 	if err != nil {
 		return nil, err
 	}
-	goTracer, _ := apm.NewTracerOptions(apm.TracerOptions{
-		ServiceName: serviceName,
-		Transport:   defaultTransport,
-	})
-	goTracer.SetLogger(logger)
-	goTracer.SetMetricsInterval(0) // disable metrics
-	goTracer.SetSpanFramesMinDuration(1 * time.Nanosecond)
-	goTracer.SetMaxSpans(maxSpans)
-
-	transport := goTracer.Transport.(*apmtransport.HTTPTransport)
 	transport.SetUserAgent("hey-apm")
 	if apiKey != "" {
 		transport.SetAPIKey(apiKey)
 	} else if serverSecret != "" {
 		transport.SetSecretToken(serverSecret)
 	}
-	if serverUrl != "" {
-		u, err := url.Parse(serverUrl)
+	if serverURL != "" {
+		u, err := url.Parse(serverURL)
 		if err != nil {
 			panic(err)
 		}
 		transport.SetServerURL(u)
 	}
-	rt := &roundTripperWrapper{roundTripper: transport.Client.Transport, c: make(chan []byte, 0)}
-	transport.Client.Transport = rt
+	roundTripper := &roundTripperWrapper{
+		roundTripper: transport.Client.Transport,
+		logger:       logger,
+		uniqueErrors: make(map[string]struct{}),
+	}
+	transport.Client.Transport = roundTripper
 
-	tracer := &Tracer{goTracer, &TransportStats{}}
-
-	// TODO confirm that synchronization is wired up correctly
-	go func() {
-		for response := range rt.c {
-			var m map[string]interface{}
-			if err := json.Unmarshal(response, &m); err != nil {
-				return
-			}
-			tracer.TransportStats.EventsAccepted += conv.AsUint64(m, "accepted")
-			tracer.TransportStats.NumRequests += 1
-			for _, i := range conv.AsSlice(m, "errors") {
-				e := conv.AsString(i, "message")
-				if !strcoll.Contains(e, tracer.TransportStats.UniqueErrors) {
-					tracer.TransportStats.UniqueErrors = append(tracer.TransportStats.UniqueErrors, e)
-				}
-			}
-			rt.wg.Done()
-		}
-	}()
-	return tracer, nil
+	goTracer, err := apm.NewTracerOptions(apm.TracerOptions{
+		ServiceName: serviceName,
+		Transport:   transport,
+	})
+	if err != nil {
+		return nil, err
+	}
+	goTracer.SetLogger(logger)
+	goTracer.SetMetricsInterval(0) // disable metrics
+	goTracer.SetSpanFramesMinDuration(1 * time.Nanosecond)
+	goTracer.SetMaxSpans(maxSpans)
+	return &Tracer{Tracer: goTracer, roundTripper: roundTripper}, nil
 }
 
 type roundTripperWrapper struct {
 	roundTripper http.RoundTripper
-	c            chan []byte
-	wg           sync.WaitGroup
+	logger       apm.Logger
+
+	statsMu      sync.RWMutex
+	stats        TransportStats
+	uniqueErrors map[string]struct{}
 }
 
 func (rt *roundTripperWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -111,20 +99,43 @@ func (rt *roundTripperWrapper) RoundTrip(req *http.Request) (*http.Response, err
 
 	resp, err := rt.roundTripper.RoundTrip(req)
 	if err != nil {
+		// Number of *failed* requests is tracked by the Go Agent.
+		rt.statsMu.Lock()
+		rt.stats.NumRequests++
+		rt.statsMu.Unlock()
 		return resp, err
 	}
 	defer resp.Body.Close()
 
-	if resp.Body == http.NoBody {
-		return resp, err
-	}
+	rt.statsMu.Lock()
+	defer rt.statsMu.Unlock()
+	rt.stats.NumRequests++
 
-	b, rerr := ioutil.ReadAll(resp.Body)
-	if rerr == nil {
-		rt.wg.Add(1)
-		rt.c <- b
-		resp.Body = ioutil.NopCloser(bytes.NewReader(b))
-	}
+	if resp.Body != http.NoBody {
+		if data, rerr := ioutil.ReadAll(resp.Body); rerr == nil {
+			resp.Body = ioutil.NopCloser(bytes.NewReader(data))
 
+			var response intakeResponse
+			if err := json.Unmarshal(data, &response); err != nil {
+				rt.logger.Errorf("failed to decode response: %s", err)
+			} else {
+				rt.stats.EventsAccepted += response.Accepted
+				for _, e := range response.Errors {
+					if _, ok := rt.uniqueErrors[e.Message]; !ok {
+						rt.uniqueErrors[e.Message] = struct{}{}
+						rt.stats.UniqueErrors = append(rt.stats.UniqueErrors, e.Message)
+					}
+				}
+			}
+		}
+	}
 	return resp, err
+}
+
+type intakeResponse struct {
+	Accepted uint64
+	Errors   []struct {
+		Message  string
+		Document string
+	}
 }

--- a/conv/conversions.go
+++ b/conv/conversions.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -67,43 +66,4 @@ func ToFloat64(i interface{}) float64 {
 		}
 		return f
 	}
-}
-
-// AsFloat64 look ups the key in m and returns its value as a float64.
-// If it fails, it returns the zero value.
-// m must be a map keyed by strings.
-func AsFloat64(m interface{}, k string) float64 {
-	return asType(m, k, float64(0)).(float64)
-}
-
-// AsUint64 look ups the key in m and returns its value as a uint64.
-// If it fails, it returns the zero value.
-// m must be a map keyed by strings.
-func AsUint64(m interface{}, k string) uint64 {
-	return uint64(AsFloat64(m, k))
-}
-
-// AsSlice look ups the key in m and returns its value as a slice of interface{}.
-// If it fails, it returns the zero value.
-// m must be a map keyed by strings.
-func AsSlice(m interface{}, k string) types.Is {
-	return asType(m, k, make(types.Is, 0)).(types.Is)
-}
-
-// AsString look ups the key in m and returns its value as a string.
-// If it fails, it returns the zero value.
-// m must be a map keyed by strings.
-func AsString(m interface{}, k string) string {
-	return asType(m, k, "").(string)
-}
-
-func asType(m interface{}, k string, v interface{}) interface{} {
-	if m2, ok := m.(types.M); ok {
-		if v2, ok := m2[k]; ok {
-			if reflect.TypeOf(v2) == reflect.TypeOf(v) {
-				return v2
-			}
-		}
-	}
-	return v
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/elastic/hey-apm/conv"
-	"github.com/elastic/hey-apm/strcoll"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,11 +23,15 @@ func TestDefaultInput(t *testing.T) {
 		"error_generation_frames_max_limit",
 		"error_generation_frames_min_limit",
 	}
+	expectedZeroValuesMap := make(map[string]bool)
+	for _, field := range expectedZeroValues {
+		expectedZeroValuesMap[field] = true
+	}
 
 	input := parseFlags()
 	assert.True(t, input.IsBenchmark)
 	for k, v := range conv.ToMap(input) {
-		if strcoll.Contains(k, expectedZeroValues) {
+		if expectedZeroValuesMap[k] {
 			continue
 		}
 		r := reflect.ValueOf(v)

--- a/strcoll/strcoll.go
+++ b/strcoll/strcoll.go
@@ -10,16 +10,6 @@ func Get(idx int, slice []string) string {
 	return ""
 }
 
-// Contains returns true if s is contained in xs.
-func Contains(s string, xs []string) bool {
-	for _, x := range xs {
-		if x == s {
-			return true
-		}
-	}
-	return false
-}
-
 // SplitKV splits strings that look like username:password.
 func SplitKV(s string, sep string) (string, string) {
 	ret := strings.SplitN(s, sep, 2)

--- a/worker/result.go
+++ b/worker/result.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"time"
 
-	"github.com/elastic/hey-apm/agent"
 	"github.com/elastic/hey-apm/strcoll"
 
 	"go.elastic.co/apm"
@@ -12,7 +11,7 @@ import (
 // Result holds stats captured from a Go agent plus timing information.
 type Result struct {
 	apm.TracerStats
-	agent.TransportStats
+	TransportStats
 	Start   time.Time
 	End     time.Time
 	Flushed time.Time

--- a/worker/run.go
+++ b/worker/run.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/hey-apm/agent"
 	"github.com/elastic/hey-apm/es"
 	"github.com/elastic/hey-apm/models"
 	"github.com/elastic/hey-apm/server"
@@ -100,7 +99,7 @@ func derefInt64(v *int64, d int64) int64 {
 // newWorker returns a new worker with with a workload defined by the input.
 func newWorker(input models.Input, stop <-chan struct{}) (*worker, error) {
 	logger := newApmLogger(log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lshortfile))
-	tracer, err := agent.NewTracer(logger, input.ApmServerUrl, input.ApmServerSecret, input.APIKey, input.ServiceName, input.SpanMaxLimit)
+	tracer, err := newTracer(logger, input.ApmServerUrl, input.ApmServerSecret, input.APIKey, input.ServiceName, input.SpanMaxLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/tracer.go
+++ b/worker/tracer.go
@@ -1,4 +1,4 @@
-package agent
+package worker
 
 import (
 	"bytes"
@@ -13,12 +13,12 @@ import (
 	apmtransport "go.elastic.co/apm/transport"
 )
 
-type Tracer struct {
+type tracer struct {
 	*apm.Tracer
 	roundTripper *roundTripperWrapper
 }
 
-func (t *Tracer) TransportStats() TransportStats {
+func (t *tracer) TransportStats() TransportStats {
 	t.roundTripper.statsMu.RLock()
 	defer t.roundTripper.statsMu.RUnlock()
 	return t.roundTripper.stats
@@ -31,12 +31,12 @@ type TransportStats struct {
 	NumRequests    uint64
 }
 
-// NewTracer returns a wrapper with a new Go agent instance and its transport stats.
-func NewTracer(
+// newTracer returns a wrapper with a new Go agent instance and its transport stats.
+func newTracer(
 	logger apm.Logger,
 	serverURL, serverSecret, apiKey, serviceName string,
 	maxSpans int,
-) (*Tracer, error) {
+) (*tracer, error) {
 
 	// Ensure that each tracer uses an independent transport.
 	transport, err := apmtransport.NewHTTPTransport()
@@ -74,7 +74,7 @@ func NewTracer(
 	goTracer.SetMetricsInterval(0) // disable metrics
 	goTracer.SetSpanFramesMinDuration(1 * time.Nanosecond)
 	goTracer.SetMaxSpans(maxSpans)
-	return &Tracer{Tracer: goTracer, roundTripper: roundTripper}, nil
+	return &tracer{Tracer: goTracer, roundTripper: roundTripper}, nil
 }
 
 type roundTripperWrapper struct {

--- a/worker/work.go
+++ b/worker/work.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/elastic/hey-apm/agent"
-
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/stacktrace"
 )
@@ -16,7 +14,7 @@ import (
 type worker struct {
 	stop   <-chan struct{} // graceful shutdown
 	logger *apmLogger
-	tracer *agent.Tracer
+	tracer *tracer
 
 	ErrorFrequency     time.Duration
 	ErrorLimit         int

--- a/worker/work.go
+++ b/worker/work.go
@@ -80,7 +80,7 @@ func (w *worker) work(ctx context.Context) (Result, error) {
 	w.flush()
 	result.Flushed = time.Now()
 	result.TracerStats = w.tracer.Stats()
-	result.TransportStats = *w.tracer.TransportStats
+	result.TransportStats = w.tracer.TransportStats()
 	return result, nil
 }
 


### PR DESCRIPTION
In `agent.Tracer`:
 - remove the separate goroutine used for measuring request/response stats and recording errors; do this in the RoundTripper wrapper itself.
- decode server responses into struct to minimise use of reflection, simplifying code and increasing type safety; remove subsequently unused `conv.As*` methods.
- use a map to track unique errors rather than `strcoll.Contains`, which has now been removed.

Move `agent.Tracer` to the `worker` package, unexporting the type (`worker.tracer`).