### PR TITLE
Use specific docker compose context

### DIFF
--- a/.ci/scripts/run-bench-in-docker.sh
+++ b/.ci/scripts/run-bench-in-docker.sh
@@ -23,6 +23,9 @@ function finish {
 
 trap finish EXIT INT TERM
 
+echo "Ensure the docker context is fresh"
+docker-compose down -v || true   ## We don't want to fail yet
+
 echo "Validate whether the ES_URL is reachable"
 curl --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,9 @@ version: "2.1"
 services:
   apm-server:
     image: ${APM_DOCKER_IMAGE:-docker.elastic.co/apm/apm-server}:${STACK_VERSION:-8.0.0-SNAPSHOT}
-    container_name: apm-server
     ports:
-      - "127.0.0.1:8200:8200"
-      - "127.0.0.1:6060:6060"
+      - "127.0.0.1:8201:8200"
+      - "127.0.0.1:6061:6060"
     command: >
       apm-server -e
         -E setup.template.settings.index.number_of_replicas=0
@@ -44,7 +43,6 @@ services:
     working_dir: /app
     command: >
       /hey-apm -bench -run 5m -rm 1.2 -apm-url http://apm-server:8200 -es-url ${ES_URL} -es-auth "${ES_USER}:${ES_PASS}" -apm-es-url ${ES_URL} -apm-es-auth "${ES_USER}:${ES_PASS}"
-    container_name: hey-apm
     environment:
       - ES_URL=${ES_URL}
       - ES_USER=${ES_USER}
@@ -62,7 +60,6 @@ services:
   validate-es-url:
     image: pstauffer/curl
     command: curl --user "${ES_USER}:${ES_PASS}" "${ES_URL}"
-    container_name: validate-es-url
     environment:
       - ES_URL=${ES_URL}
       - ES_USER=${ES_USER}


### PR DESCRIPTION
### What

Run docker-compose down -v before running the hey-apm tests, to ensure the context is clean and no left-overs from previous builds are still running.

Map a different port for the apm-server to ensure the baremetal context is specific for the hey-apm, we cannot assure that those baremetals are clean since they are multi-tenant

Use the service name instead forcing a name with the name of the service, this will delegate the naming to the docker-compose since it will add some prefix to those containers.

 